### PR TITLE
feat: activate live chat worker routes and demo UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,66 @@
 
 ## Objective
 
-Provide a Cloudflare-native AI prototype surface for hardened JSON-contract responses and route-based API experimentation.
+Provide a Cloudflare-native AI prototype surface for:
+
+- live browser chat
+- route-based API experimentation
+- hardened JSON-contract analysis
 
 ## Current Role
 
-This repository is a prototype and testing lane for Worker-based AI endpoints, not the canonical BranchOps internal control plane.
+This repository is a public-safe prototype lane for Worker-based AI endpoints, not the canonical BranchOps internal control plane.
+
+## Live Routes
+
+- `GET /` — browser chat demo UI
+- `GET /health` — health/status response
+- `POST /chat` — conversational endpoint
+- `POST /analyze` — structured JSON-contract endpoint
+
+## Request Shapes
+
+### Chat
+
+```json
+{
+  "sessionId": "demo-session-001",
+  "messages": [
+    { "role": "user", "content": "What can this bot help with?" }
+  ]
+}
+```
+
+You can also send a single string with:
+
+```json
+{
+  "input": "What can this bot help with?"
+}
+```
+
+### Analyze
+
+```json
+{
+  "input": "Turn this idea into a structured business asset."
+}
+```
+
+## Local Development
+
+```bash
+npm install
+npm run dev
+```
+
+## Deploy
+
+```bash
+npm run deploy
+```
+
+After deploy, open the Worker root URL to use the built-in browser chat demo.
 
 ## Boundary Rules
 
@@ -20,6 +75,9 @@ This repository is a prototype and testing lane for Worker-based AI endpoints, n
 - Internal operating platform: `OffDaBranch/branchops-platform`
 - Public product narrative: `OffDaBranch/branchops-public`
 
-## Follow-Up
+## Next Hardening Steps
 
-Normalize branch and repository settings in GitHub UI so the long-term stable branch posture is explicit.
+- add persistent memory with D1 or Durable Objects
+- add rate limiting and abuse controls
+- add prompt/version management
+- add Airtable or webhook logging for qualified conversations

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,28 @@ type AiBinding = {
 	run: (model: string, inputs: Record<string, unknown>) => Promise<AiRunResult>;
 };
 
+type ChatRole = "system" | "user" | "assistant";
+
+type ChatMessage = {
+	role: ChatRole;
+	content: string;
+};
+
+type ChatRequestBody = {
+	sessionId?: string;
+	messages?: ChatMessage[];
+	input?: string;
+	instructions?: string;
+	max_tokens?: number;
+	temperature?: number;
+};
+
+type AnalyzeRequestBody = {
+	input?: string;
+	instructions?: string;
+	max_tokens?: number;
+};
+
 export interface Env {
 	AI: AiBinding;
 }
@@ -43,8 +65,290 @@ export type BranchOpsResponse = {
 };
 
 const MODEL = "@cf/openai/gpt-oss-120b";
-const DEFAULT_INSTRUCTIONS =
+
+const DEFAULT_ANALYZE_INSTRUCTIONS =
 	"Return valid JSON only with keys: objective, classification, monetization_model, risks, next_actions. Type rules: objective must be a string, classification must be a single string label, monetization_model must be an object, risks must be an array of strings, and next_actions must be an array of strings. Do not return nested objects for classification or risks.";
+
+const DEFAULT_CHAT_INSTRUCTIONS = [
+	"You are Hello AI for Off Da Branch.",
+	"You are a public-safe strategic assistant.",
+	"Be direct, structured, and useful.",
+	"Prefer ownership, automation, licensing, recurring revenue, and scalable systems when advising on business ideas.",
+	"Flag legal, tax, privacy, safety, compliance, and IP risks when relevant.",
+	"Do not invent facts. Say when information is missing.",
+].join(" ");
+
+const MAX_CHAT_MESSAGES = 20;
+
+const CHAT_DEMO_HTML = `<!doctype html>
+<html lang="en">
+<head>
+	<meta charset="utf-8" />
+	<meta name="viewport" content="width=device-width, initial-scale=1" />
+	<title>Hello AI</title>
+	<style>
+		:root {
+			color-scheme: dark;
+			font-family: Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+			background: #0b0f14;
+			color: #e7edf5;
+		}
+		* { box-sizing: border-box; }
+		body {
+			margin: 0;
+			background: linear-gradient(180deg, #0b0f14 0%, #111827 100%);
+			min-height: 100vh;
+		}
+		.wrapper {
+			max-width: 960px;
+			margin: 0 auto;
+			padding: 24px 16px 48px;
+		}
+		.hero {
+			margin-bottom: 16px;
+		}
+		h1 {
+			margin: 0 0 8px;
+			font-size: 2rem;
+		}
+		p, li, code, textarea, button, input {
+			font-size: 0.98rem;
+		}
+		.small {
+			color: #9fb0c3;
+		}
+		.panel {
+			background: rgba(17, 24, 39, 0.92);
+			border: 1px solid rgba(148, 163, 184, 0.2);
+			border-radius: 16px;
+			padding: 16px;
+			box-shadow: 0 16px 48px rgba(0, 0, 0, 0.22);
+		}
+		.chat-log {
+			min-height: 360px;
+			max-height: 60vh;
+			overflow-y: auto;
+			display: flex;
+			flex-direction: column;
+			gap: 12px;
+			padding: 4px 2px 12px;
+			margin-bottom: 16px;
+		}
+		.message {
+			padding: 12px 14px;
+			border-radius: 14px;
+			white-space: pre-wrap;
+			line-height: 1.45;
+		}
+		.message.user {
+			background: rgba(59, 130, 246, 0.2);
+			border: 1px solid rgba(96, 165, 250, 0.28);
+		}
+		.message.assistant {
+			background: rgba(34, 197, 94, 0.14);
+			border: 1px solid rgba(74, 222, 128, 0.22);
+		}
+		.message.system {
+			background: rgba(148, 163, 184, 0.12);
+			border: 1px solid rgba(148, 163, 184, 0.16);
+		}
+		.meta {
+			font-size: 0.8rem;
+			color: #9fb0c3;
+			margin-bottom: 6px;
+			text-transform: uppercase;
+			letter-spacing: 0.04em;
+		}
+		form {
+			display: grid;
+			gap: 12px;
+		}
+		textarea {
+			width: 100%;
+			min-height: 120px;
+			resize: vertical;
+			padding: 14px;
+			border-radius: 12px;
+			border: 1px solid rgba(148, 163, 184, 0.24);
+			background: #0f172a;
+			color: #e7edf5;
+		}
+		.actions {
+			display: flex;
+			gap: 12px;
+			flex-wrap: wrap;
+		}
+		button {
+			padding: 12px 16px;
+			border-radius: 12px;
+			border: 1px solid rgba(148, 163, 184, 0.22);
+			background: #111827;
+			color: #e7edf5;
+			cursor: pointer;
+		}
+		button.primary {
+			background: #2563eb;
+			border-color: #2563eb;
+		}
+		.routes {
+			margin-top: 18px;
+		}
+		code {
+			background: rgba(15, 23, 42, 0.9);
+			padding: 2px 6px;
+			border-radius: 8px;
+		}
+	</style>
+</head>
+<body>
+	<div class="wrapper">
+		<div class="hero">
+			<h1>Hello AI</h1>
+			<p>Cloudflare Worker chatbot demo and JSON analyzer for Off Da Branch.</p>
+			<p class="small">This browser demo stores conversation history locally and sends the rolling transcript to <code>/chat</code>.</p>
+		</div>
+
+		<div class="panel">
+			<div id="chatLog" class="chat-log"></div>
+
+			<form id="chatForm">
+				<textarea id="messageInput" placeholder="Ask a question, test a workflow, or describe an idea..."></textarea>
+				<div class="actions">
+					<button class="primary" type="submit">Send</button>
+					<button id="clearBtn" type="button">Clear local chat</button>
+				</div>
+			</form>
+
+			<div class="routes">
+				<p class="small">API routes: <code>GET /health</code>, <code>POST /chat</code>, <code>POST /analyze</code></p>
+			</div>
+		</div>
+	</div>
+
+	<script>
+		(function () {
+			var STORAGE_KEY = 'hello-ai-demo-history';
+			var SESSION_KEY = 'hello-ai-demo-session';
+			var chatLog = document.getElementById('chatLog');
+			var form = document.getElementById('chatForm');
+			var input = document.getElementById('messageInput');
+			var clearBtn = document.getElementById('clearBtn');
+
+			var sessionId = localStorage.getItem(SESSION_KEY) || crypto.randomUUID();
+			localStorage.setItem(SESSION_KEY, sessionId);
+
+			var messages = [];
+			try {
+				var saved = localStorage.getItem(STORAGE_KEY);
+				if (saved) {
+					messages = JSON.parse(saved);
+				}
+			} catch (error) {
+				messages = [];
+			}
+
+			if (!Array.isArray(messages) || messages.length === 0) {
+				messages = [
+					{
+						role: 'assistant',
+						content: 'Hello. This demo is live. Ask a question to test the Worker chat route.'
+					}
+				];
+				persist();
+			}
+
+			function persist() {
+				localStorage.setItem(STORAGE_KEY, JSON.stringify(messages));
+			}
+
+			function render() {
+				chatLog.innerHTML = '';
+				messages.forEach(function (message) {
+					var wrapper = document.createElement('div');
+					wrapper.className = 'message ' + message.role;
+
+					var meta = document.createElement('div');
+					meta.className = 'meta';
+					meta.textContent = message.role;
+
+					var content = document.createElement('div');
+					content.textContent = message.content;
+
+					wrapper.appendChild(meta);
+					wrapper.appendChild(content);
+					chatLog.appendChild(wrapper);
+				});
+				chatLog.scrollTop = chatLog.scrollHeight;
+			}
+
+			async function sendMessage(text) {
+				messages.push({ role: 'user', content: text });
+				render();
+				persist();
+
+				var pending = { role: 'assistant', content: 'Thinking...' };
+				messages.push(pending);
+				render();
+
+				try {
+					var response = await fetch('/chat', {
+						method: 'POST',
+						headers: { 'Content-Type': 'application/json' },
+						body: JSON.stringify({
+							sessionId: sessionId,
+							messages: messages.filter(function (message) {
+								return message !== pending;
+							})
+						})
+					});
+
+					var payload = await response.json();
+
+					if (!response.ok || !payload.ok) {
+						throw new Error(payload.error || 'Request failed.');
+					}
+
+					sessionId = payload.sessionId || sessionId;
+					localStorage.setItem(SESSION_KEY, sessionId);
+					pending.content = payload.reply || 'No reply returned.';
+				} catch (error) {
+					pending.content = 'Error: ' + (error && error.message ? error.message : 'Unknown error');
+				}
+
+				render();
+				persist();
+			}
+
+			form.addEventListener('submit', function (event) {
+				event.preventDefault();
+				var text = input.value.trim();
+				if (!text) {
+					return;
+				}
+				input.value = '';
+				sendMessage(text);
+			});
+
+			clearBtn.addEventListener('click', function () {
+				localStorage.removeItem(STORAGE_KEY);
+				localStorage.removeItem(SESSION_KEY);
+				sessionId = crypto.randomUUID();
+				localStorage.setItem(SESSION_KEY, sessionId);
+				messages = [
+					{
+						role: 'assistant',
+						content: 'Local chat cleared. Start a new conversation.'
+					}
+				];
+				persist();
+				render();
+			});
+
+			render();
+		})();
+	</script>
+</body>
+</html>`;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null;
@@ -52,6 +356,10 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function isStringArray(value: unknown): value is string[] {
 	return Array.isArray(value) && value.every((item) => typeof item === "string");
+}
+
+function isChatRole(value: unknown): value is ChatRole {
+	return value === "system" || value === "user" || value === "assistant";
 }
 
 function normalizeString(value: unknown): string | null {
@@ -124,9 +432,7 @@ function normalizeStringList(value: unknown, includeKeys = false): string[] | nu
 				return item
 					.map((entry) => entry.trim())
 					.filter((entry) => entry.length > 0)
-					.map((entry) =>
-						includeKeys ? `${formatObjectKey(key)}: ${entry}` : entry,
-					);
+					.map((entry) => (includeKeys ? formatObjectKey(key) + ": " + entry : entry));
 			}
 
 			const stringValue = normalizeString(item);
@@ -134,7 +440,7 @@ function normalizeStringList(value: unknown, includeKeys = false): string[] | nu
 				return [];
 			}
 
-			return [includeKeys ? `${formatObjectKey(key)}: ${stringValue}` : stringValue];
+			return [includeKeys ? formatObjectKey(key) + ": " + stringValue : stringValue];
 		})
 		.filter((item) => item.length > 0);
 
@@ -185,6 +491,28 @@ export function extractOutputText(result: AiRunResult): string | null {
 	return null;
 }
 
+function getModelText(raw: AiRunResult): string | null {
+	if (typeof raw.response === "string") {
+		const trimmed = raw.response.trim();
+		return trimmed ? trimmed : null;
+	}
+
+	const outputText = extractOutputText(raw);
+	if (outputText) {
+		return outputText;
+	}
+
+	if (raw.response !== undefined) {
+		try {
+			return JSON.stringify(raw.response);
+		} catch {
+			return null;
+		}
+	}
+
+	return null;
+}
+
 function parseModelResponse(
 	raw: AiRunResult,
 ): { parsed: unknown; rawText: string | null } | { error: string; rawText: string | null } {
@@ -212,97 +540,223 @@ function parseModelResponse(
 	}
 }
 
+function sanitizeMessages(value: unknown): ChatMessage[] {
+	if (!Array.isArray(value)) {
+		return [];
+	}
+
+	return value
+		.flatMap((item) => {
+			if (!isRecord(item) || !isChatRole(item.role)) {
+				return [];
+			}
+
+			const content = normalizeString(item.content);
+			if (!content) {
+				return [];
+			}
+
+			return [{ role: item.role, content }];
+		})
+		.slice(-MAX_CHAT_MESSAGES);
+}
+
+function buildConversationInput(messages: ChatMessage[]): string {
+	return messages
+		.map((message) => message.role.toUpperCase() + ": " + message.content)
+		.join("\n\n");
+}
+
+function getSessionId(value: unknown): string {
+	const normalized = normalizeString(value);
+	return normalized ?? crypto.randomUUID();
+}
+
+function corsHeaders(): HeadersInit {
+	return {
+		"Access-Control-Allow-Origin": "*",
+		"Access-Control-Allow-Methods": "GET,POST,OPTIONS",
+		"Access-Control-Allow-Headers": "Content-Type",
+		"Cache-Control": "no-store",
+	};
+}
+
+function jsonResponse(body: unknown, init?: ResponseInit): Response {
+	const headers = new Headers(init?.headers);
+	for (const [key, value] of Object.entries(corsHeaders())) {
+		headers.set(key, value);
+	}
+	headers.set("Content-Type", "application/json; charset=utf-8");
+	return new Response(JSON.stringify(body, null, 2), {
+		...init,
+		headers,
+	});
+}
+
+function htmlResponse(html: string, init?: ResponseInit): Response {
+	const headers = new Headers(init?.headers);
+	for (const [key, value] of Object.entries(corsHeaders())) {
+		headers.set(key, value);
+	}
+	headers.set("Content-Type", "text/html; charset=utf-8");
+	return new Response(html, {
+		...init,
+		headers,
+	});
+}
+
+async function readJson<T>(request: Request): Promise<T> {
+	return (await request.json()) as T;
+}
+
 export default {
-	async fetch(request: Request, env: Env): Promise<Response> {
-		if (request.method === "GET") {
-			return Response.json({
+	async fetch(request: Request, env: Env, _ctx: ExecutionContext): Promise<Response> {
+		const url = new URL(request.url);
+
+		if (request.method === "OPTIONS") {
+			return new Response(null, {
+				status: 204,
+				headers: corsHeaders(),
+			});
+		}
+
+		if (request.method === "GET" && url.pathname === "/") {
+			return htmlResponse(CHAT_DEMO_HTML);
+		}
+
+		if (request.method === "GET" && url.pathname === "/health") {
+			return jsonResponse({
 				ok: true,
-				message: 'Send a POST request with JSON like { "input": "your prompt" }',
-				route: "/",
+				service: "hello-ai",
 				model: MODEL,
+				routes: {
+					chat: "POST /chat",
+					analyze: "POST /analyze",
+					health: "GET /health",
+				},
 			});
 		}
 
-		if (request.method !== "POST") {
-			return Response.json(
-				{ ok: false, error: "Method not allowed. Use POST." },
-				{ status: 405 },
-			);
-		}
+		if (request.method === "POST" && url.pathname === "/chat") {
+			let body: ChatRequestBody;
 
-		let body: {
-			input?: string;
-			instructions?: string;
-			max_tokens?: number;
-		};
+			try {
+				body = await readJson<ChatRequestBody>(request);
+			} catch {
+				return jsonResponse({ ok: false, error: "Invalid JSON body." }, { status: 400 });
+			}
 
-		try {
-			body = await request.json<typeof body>();
-		} catch {
-			return Response.json(
-				{ ok: false, error: "Invalid JSON body." },
-				{ status: 400 },
-			);
-		}
+			const sanitizedMessages = sanitizeMessages(body.messages);
+			const fallbackInput = normalizeString(body.input);
+			const messages =
+				sanitizedMessages.length > 0
+					? sanitizedMessages
+					: fallbackInput
+						? [{ role: "user" as const, content: fallbackInput }]
+						: [];
 
-		if (!body.input || !body.input.trim()) {
-			return Response.json(
-				{ ok: false, error: "Missing 'input'." },
-				{ status: 400 },
-			);
-		}
-
-		try {
-			const raw = await env.AI.run(MODEL, {
-				instructions: body.instructions ?? DEFAULT_INSTRUCTIONS,
-				input: body.input,
-				max_tokens: body.max_tokens ?? 700,
-				temperature: 0.2,
-			});
-
-			const parsedResponse = parseModelResponse(raw);
-			if ("error" in parsedResponse) {
-				return Response.json(
-					{
-						ok: false,
-						error: parsedResponse.error,
-						model: MODEL,
-						...(parsedResponse.rawText
-							? {
-									raw_text: parsedResponse.rawText,
-							  }
-							: {}),
-					},
-					{ status: 502 },
+			if (messages.length === 0) {
+				return jsonResponse(
+					{ ok: false, error: "Missing 'messages' or 'input'." },
+					{ status: 400 },
 				);
 			}
 
-			const normalized = normalizeBranchOpsResponse(parsedResponse.parsed);
-			if (!normalized) {
-				return Response.json(
-					{
-						ok: false,
-						error: "Model returned invalid JSON contract.",
-						model: MODEL,
-						...(parsedResponse.rawText
-							? {
-									raw_text: parsedResponse.rawText,
-							  }
-							: {}),
-					},
-					{ status: 502 },
-				);
+			try {
+				const raw = await env.AI.run(MODEL, {
+					instructions: body.instructions ?? DEFAULT_CHAT_INSTRUCTIONS,
+					input: buildConversationInput(messages),
+					max_tokens: body.max_tokens ?? 700,
+					temperature: typeof body.temperature === "number" ? body.temperature : 0.4,
+				});
+
+				const reply = getModelText(raw);
+				if (!reply) {
+					return jsonResponse(
+						{ ok: false, error: "Model returned no usable chat text.", model: MODEL },
+						{ status: 502 },
+					);
+				}
+
+				return jsonResponse({
+					ok: true,
+					sessionId: getSessionId(body.sessionId),
+					model: MODEL,
+					reply,
+					usage: raw.usage ?? null,
+				});
+			} catch (error) {
+				const message = error instanceof Error ? error.message : "Unknown error";
+				return jsonResponse({ ok: false, error: message }, { status: 500 });
+			}
+		}
+
+		if (request.method === "POST" && url.pathname === "/analyze") {
+			let body: AnalyzeRequestBody;
+
+			try {
+				body = await readJson<AnalyzeRequestBody>(request);
+			} catch {
+				return jsonResponse({ ok: false, error: "Invalid JSON body." }, { status: 400 });
 			}
 
-			return Response.json({
-				ok: true,
-				model: MODEL,
-				data: normalized,
-				usage: raw.usage ?? null,
-			});
-		} catch (error) {
-			const message = error instanceof Error ? error.message : "Unknown error";
-			return Response.json({ ok: false, error: message }, { status: 500 });
+			if (!body.input || !body.input.trim()) {
+				return jsonResponse({ ok: false, error: "Missing 'input'." }, { status: 400 });
+			}
+
+			try {
+				const raw = await env.AI.run(MODEL, {
+					instructions: body.instructions ?? DEFAULT_ANALYZE_INSTRUCTIONS,
+					input: body.input,
+					max_tokens: body.max_tokens ?? 700,
+					temperature: 0.2,
+				});
+
+				const parsedResponse = parseModelResponse(raw);
+				if ("error" in parsedResponse) {
+					return jsonResponse(
+						{
+							ok: false,
+							error: parsedResponse.error,
+							model: MODEL,
+							...(parsedResponse.rawText ? { raw_text: parsedResponse.rawText } : {}),
+						},
+						{ status: 502 },
+					);
+				}
+
+				const normalized = normalizeBranchOpsResponse(parsedResponse.parsed);
+				if (!normalized) {
+					return jsonResponse(
+						{
+							ok: false,
+							error: "Model returned invalid JSON contract.",
+							model: MODEL,
+							...(parsedResponse.rawText ? { raw_text: parsedResponse.rawText } : {}),
+						},
+						{ status: 502 },
+					);
+				}
+
+				return jsonResponse({
+					ok: true,
+					model: MODEL,
+					data: normalized,
+					usage: raw.usage ?? null,
+				});
+			} catch (error) {
+				const message = error instanceof Error ? error.message : "Unknown error";
+				return jsonResponse({ ok: false, error: message }, { status: 500 });
+			}
 		}
+
+		return jsonResponse(
+			{
+				ok: false,
+				error: "Not found.",
+				available_routes: ["GET /", "GET /health", "POST /chat", "POST /analyze"],
+			},
+			{ status: 404 },
+		);
 	},
 } satisfies ExportedHandler<Env>;

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -13,8 +13,21 @@ function createEnv(response: Awaited<ReturnType<Env["AI"]["run"]>>): Env {
 }
 
 describe("hello-ai worker", () => {
-	it("returns route instructions on GET", async () => {
-		const request = new IncomingRequest("http://example.com");
+	it("returns the browser chat demo on GET /", async () => {
+		const request = new IncomingRequest("http://example.com/");
+		const ctx = createExecutionContext();
+		const response = await worker.fetch(request, createEnv({}), ctx);
+
+		await waitOnExecutionContext(ctx);
+		expect(response.status).toBe(200);
+		expect(response.headers.get("content-type")).toContain("text/html");
+		const html = await response.text();
+		expect(html).toContain("<title>Hello AI</title>");
+		expect(html).toContain("POST /chat");
+	});
+
+	it("returns health metadata on GET /health", async () => {
+		const request = new IncomingRequest("http://example.com/health");
 		const ctx = createExecutionContext();
 		const response = await worker.fetch(request, createEnv({}), ctx);
 
@@ -22,14 +35,68 @@ describe("hello-ai worker", () => {
 		expect(response.status).toBe(200);
 		await expect(response.json()).resolves.toEqual({
 			ok: true,
-			message: 'Send a POST request with JSON like { "input": "your prompt" }',
-			route: "/",
+			service: "hello-ai",
 			model: "@cf/openai/gpt-oss-120b",
+			routes: {
+				chat: "POST /chat",
+				analyze: "POST /analyze",
+				health: "GET /health",
+			},
 		});
 	});
 
-	it("returns only parsed data and usage on successful POST", async () => {
-		const request = new IncomingRequest("http://example.com", {
+	it("returns a conversational response on POST /chat", async () => {
+		const request = new IncomingRequest("http://example.com/chat", {
+			method: "POST",
+			headers: {
+				"content-type": "application/json",
+			},
+			body: JSON.stringify({
+				sessionId: "session-123",
+				messages: [{ role: "user", content: "What can this bot help with?" }],
+			}),
+		});
+		const ctx = createExecutionContext();
+		const response = await worker.fetch(
+			request,
+			createEnv({
+				output: [
+					{
+						type: "message",
+						content: [
+							{
+								type: "output_text",
+								text: "It can answer questions and help structure ideas.",
+							},
+						],
+					},
+				],
+				usage: {
+					input_tokens: 12,
+					output_tokens: 15,
+					total_tokens: 27,
+				},
+			}),
+			ctx,
+		);
+
+		await waitOnExecutionContext(ctx);
+		expect(response.status).toBe(200);
+		await expect(response.json()).resolves.toEqual({
+			ok: true,
+			sessionId: "session-123",
+			model: "@cf/openai/gpt-oss-120b",
+			reply: "It can answer questions and help structure ideas.",
+			usage: {
+				input_tokens: 12,
+				output_tokens: 15,
+				total_tokens: 27,
+			},
+		});
+	});
+
+	it("returns only parsed data and usage on successful POST /analyze", async () => {
+		const request = new IncomingRequest("http://example.com/analyze", {
 			method: "POST",
 			headers: {
 				"content-type": "application/json",
@@ -90,7 +157,7 @@ describe("hello-ai worker", () => {
 	});
 
 	it("normalizes common model drift into the public contract", async () => {
-		const request = new IncomingRequest("http://example.com", {
+		const request = new IncomingRequest("http://example.com/analyze", {
 			method: "POST",
 			headers: {
 				"content-type": "application/json",
@@ -120,8 +187,10 @@ describe("hello-ai worker", () => {
 										type: "subscription",
 									},
 									risks: {
-										regulatory_compliance: "Training content may require certification review",
-										data_privacy: "Employee performance data creates privacy obligations",
+										regulatory_compliance:
+											"Training content may require certification review",
+										data_privacy:
+											"Employee performance data creates privacy obligations",
 									},
 									next_actions: [
 										"Validate the first buyer segment",
@@ -169,23 +238,27 @@ describe("hello-ai worker", () => {
 		});
 	});
 
-	it("rejects unsupported methods", async () => {
-		const request = new IncomingRequest("http://example.com", {
-			method: "PUT",
+	it("returns 400 when chat input is missing", async () => {
+		const request = new IncomingRequest("http://example.com/chat", {
+			method: "POST",
+			headers: {
+				"content-type": "application/json",
+			},
+			body: JSON.stringify({}),
 		});
 		const ctx = createExecutionContext();
 		const response = await worker.fetch(request, createEnv({}), ctx);
 
 		await waitOnExecutionContext(ctx);
-		expect(response.status).toBe(405);
+		expect(response.status).toBe(400);
 		await expect(response.json()).resolves.toEqual({
 			ok: false,
-			error: "Method not allowed. Use POST.",
+			error: "Missing 'messages' or 'input'.",
 		});
 	});
 
-	it("returns 502 when the model emits non-JSON text", async () => {
-		const request = new IncomingRequest("http://example.com", {
+	it("returns 502 when analyze emits non-JSON text", async () => {
+		const request = new IncomingRequest("http://example.com/analyze", {
 			method: "POST",
 			headers: {
 				"content-type": "application/json",


### PR DESCRIPTION
## Summary
- add live `POST /chat` route for conversational responses
- move structured contract output to `POST /analyze`
- add `GET /health` and a browser chat demo on `GET /`
- update tests and README for the new route structure

## Why
The repo was still a structured prototype endpoint and not an active chatbot. This PR turns it into a usable chat surface while preserving the JSON analyzer lane.

## Notes
- preserves the existing Cloudflare AI binding
- keeps the repo public-safe and prototype-scoped
- next hardening step should be D1 or Durable Objects for persistent memory
