### PR TITLE
Make hello-ai validation non-watch

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"deploy": "wrangler deploy",
 		"dev": "wrangler dev",
 		"start": "wrangler dev",
-		"test": "vitest",
+		"test": "vitest run",
 		"validate": "npm run build && npm run test",
 		"cf-typegen": "wrangler types"
 	},


### PR DESCRIPTION
## Objective

Make the BranchOps AI Intake Worker validation command exit cleanly instead of staying in Vitest watch mode.

## Asset

- Asset Name: BranchOps AI Intake Worker
- Asset ID: BOH-AI-INTAKE-001
- Owner: Branch Off Holdings LLC
- Runtime: Cloudflare Workers + Workers AI + D1

## Changes

- Changed `package.json` test script from `vitest` to `vitest run`.
- Keeps `npm run validate` usable for local validation and future CI.

## Validation

- [x] npm run validate
- [x] npm run deploy:dry-run

## Notes

- This PR does not address the `undici` audit warnings because npm reports the available fix requires a breaking upgrade to `@cloudflare/vitest-pool-workers@0.15.1`.
- Dependency security remediation should be handled in a separate controlled PR.