### PR TITLE
Add intake lead capture and export

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This repository is the public-safe same-day intake Worker for BranchOps asset pl
 | `GET` | `/health` | Return status, asset metadata, route contracts, and runtime requirements | JSON metadata and route contracts |
 | `POST` | `/chat` | Run conversational chat and persist the transcript to D1 | `sessionId`, `reply`, `usage` |
 | `POST` | `/analyze` | Convert a raw idea into a structured BranchOps asset plan | BranchOps planning schema |
+| `GET` | `/admin/export/intake-leads` | Export captured lead records when admin export is configured | Bearer-token protected CSV |
 
 The browser UI includes intake mode menu options for general asset planning, licensing, automation, apps, content/media, grants/workforce, real estate, clothing/brand/IP, food or infused product R&D, and compliance review.
 
@@ -65,6 +66,12 @@ The browser UI includes intake mode menu options for general asset planning, lic
   "audience": "optional target audience",
   "urgency": "optional timing signal",
   "budget": "optional budget signal",
+  "name": "optional lead name",
+  "email": "optional lead email",
+  "phone": "optional lead phone",
+  "business_name": "optional business name",
+  "location": "optional location",
+  "preferred_contact": "optional contact preference",
   "instructions": "optional non-empty string",
   "max_tokens": 700
 }
@@ -74,9 +81,12 @@ Validation rules:
 
 - `content-type` must include `application/json`
 - body must be a JSON object
-- `/analyze` allows only `input`, `mode`, `audience`, `urgency`, `budget`, `instructions`, and `max_tokens`
+- `/analyze` allows only `input`, `mode`, `audience`, `urgency`, `budget`, `name`, `email`, `phone`, `business_name`, `location`, `preferred_contact`, `instructions`, and `max_tokens`
 - `input` is required and capped at `8000` characters
 - `mode`, `audience`, `urgency`, and `budget` are capped at `200` characters each
+- lead fields are optional and length-capped
+- `email` must look like a valid email address when provided
+- `phone` is lenient but capped at `40` characters
 - `instructions` is capped at `2000` characters
 - `max_tokens` must be an integer between `1` and `700`
 - `/chat` also supports `sessionId`, `messages`, and `temperature`
@@ -164,6 +174,24 @@ Every JSON response includes `request_id`. `/chat` and `/analyze` use a safe def
 
 The log intentionally does not store full prompt, chat, reply, or idea content by default.
 
+## Lead Capture And Export
+
+Optional lead fields on `/analyze` are stored in `intake_leads` only when at least one lead field is provided. The full private prompt is not stored in the lead table.
+
+`GET /admin/export/intake-leads` returns a CSV export with:
+
+- `request_id`
+- `name`
+- `email`
+- `phone`
+- `business_name`
+- `location`
+- `preferred_contact`
+- `mode`
+- `created_at`
+
+Admin export is protected by `Authorization: Bearer <token>` when `ADMIN_EXPORT_TOKEN` is configured. If `ADMIN_EXPORT_TOKEN` is missing, the route returns `503` with a safe JSON message explaining that admin export is not configured. No secret is hardcoded in this repo.
+
 ## Environment Requirements
 
 Runtime bindings:
@@ -176,6 +204,7 @@ D1 schema:
 - `chat_sessions`
 - `chat_messages`
 - `intake_events`
+- `intake_leads`
 
 Operator requirements:
 

--- a/docs/ASSET_REGISTER.md
+++ b/docs/ASSET_REGISTER.md
@@ -14,6 +14,8 @@ The Worker supports intake for advisory, implementation, and licensing workflows
 
 The current intake modes cover business assets, royalty models, automation workflows, digital products/apps, content/media assets, grants/workforce programs, real estate/property systems, clothing/brand/IP assets, food or infused product R&D, and compliance/risk review.
 
+Optional lead capture supports follow-up workflows when a submitter chooses to provide contact details. Captured lead records are export-ready through a bearer-token protected CSV route when `ADMIN_EXPORT_TOKEN` is configured.
+
 ## Licensing Potential
 
 The structured intake contract can become a licensable module for founder studios, operators, agencies, and business formation workflows that need repeatable idea-to-asset planning.
@@ -25,12 +27,14 @@ The structured intake contract can become a licensable module for founder studio
 - Include attorney, tax, privacy, and compliance review before executing regulated recommendations.
 - Do not hardcode secrets or private BranchOps operating records in this repository.
 - Structured D1 logs should store request metadata, status, token usage, and error details only; do not store full idea, chat, or reply content by default.
+- `intake_leads` may contain personal contact data when submitted voluntarily; export access must stay token-protected and the token must be stored as a Cloudflare secret.
 - Basic per-IP throttling is an abuse-control guardrail, not a substitute for authenticated platform-level rate limits.
 
 ## Promotion Path Into BranchOps Platform
 
 1. Prove the public-safe intake schema through this Worker.
 2. Use `request_id` and `intake_events` to trace public-safe route behavior.
-3. Add authenticated intake capture and review queues in the internal BranchOps Platform.
-4. Promote qualified plans into asset records, task workflows, and owner dashboards.
-5. Add reporting for conversion, revenue attribution, licensing candidates, and compliance review status.
+3. Use `intake_leads` CSV export as the temporary bridge into manual review.
+4. Add authenticated intake capture and review queues in the internal BranchOps Platform.
+5. Promote qualified plans into asset records, task workflows, and owner dashboards.
+6. Add reporting for conversion, revenue attribution, licensing candidates, and compliance review status.

--- a/docs/CODEX_OPERATOR_SOP.md
+++ b/docs/CODEX_OPERATOR_SOP.md
@@ -16,7 +16,8 @@ npm install
 ```
 
 4. Confirm Cloudflare access is available through `wrangler login` or a scoped `CLOUDFLARE_API_TOKEN`.
-5. Confirm the D1 database has the current schema from `schema.sql`, including `intake_events`, before expecting structured event logs.
+5. Confirm the D1 database has the current schema from `schema.sql`, including `intake_events` and `intake_leads`, before expecting structured event logs or lead export.
+6. Configure `ADMIN_EXPORT_TOKEN` as a Cloudflare secret only when admin CSV export should be enabled. Do not commit or hardcode the token.
 
 ## Local Dev
 
@@ -33,7 +34,7 @@ Use the local Wrangler URL to inspect:
 - `POST /chat`
 - `POST /analyze`
 
-The browser page should show the BranchOps intake mode menu. `/chat` and `/analyze` JSON responses should include `request_id`.
+The browser page should show the BranchOps intake mode menu and an optional contact info section. `/chat` and `/analyze` JSON responses should include `request_id`.
 
 ## Validation
 
@@ -75,7 +76,10 @@ Confirm:
 
 - `request_id` appears on all JSON responses.
 - `/analyze` accepts optional `mode`, `audience`, `urgency`, and `budget`.
+- `/analyze` accepts optional lead fields and rejects malformed email values.
 - `/chat` and `/analyze` create public-safe `intake_events` rows without storing full content.
+- lead submissions create `intake_leads` rows linked by `request_id` without storing full prompt content.
+- `GET /admin/export/intake-leads` returns `503` until `ADMIN_EXPORT_TOKEN` is configured.
 - Throttled requests return `429` with `request_id`.
 
 ## Rollback
@@ -103,7 +107,7 @@ git status
 
 ```powershell
 git add README.md docs/CODEX_OPERATOR_SOP.md docs/ASSET_REGISTER.md schema.sql src/index.ts test/index.spec.ts
-git commit -m "Add BranchOps intake controls and logs"
+git commit -m "Add intake lead capture and export"
 ```
 
 5. Push the active branch:

--- a/schema.sql
+++ b/schema.sql
@@ -39,3 +39,22 @@ ON intake_events(route, status);
 
 CREATE INDEX IF NOT EXISTS idx_intake_events_timestamp
 ON intake_events(timestamp);
+
+CREATE TABLE IF NOT EXISTS intake_leads (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  request_id TEXT NOT NULL,
+  name TEXT,
+  email TEXT,
+  phone TEXT,
+  business_name TEXT,
+  location TEXT,
+  preferred_contact TEXT,
+  mode TEXT,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_intake_leads_request_id
+ON intake_leads(request_id);
+
+CREATE INDEX IF NOT EXISTS idx_intake_leads_created_at
+ON intake_leads(created_at);

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,8 +52,29 @@ type AnalyzeRequestBody = {
 	audience?: string;
 	urgency?: string;
 	budget?: string;
+	name?: string;
+	email?: string;
+	phone?: string;
+	business_name?: string;
+	location?: string;
+	preferred_contact?: string;
 	instructions?: string;
 	max_tokens?: number;
+};
+
+type LeadFields = {
+	name?: string;
+	email?: string;
+	phone?: string;
+	business_name?: string;
+	location?: string;
+	preferred_contact?: string;
+};
+
+type LeadExportRow = LeadFields & {
+	request_id: string;
+	mode: string | null;
+	created_at: string;
 };
 
 type ValidatedAnalyzeRequestBody = {
@@ -62,6 +83,7 @@ type ValidatedAnalyzeRequestBody = {
 	audience?: string;
 	urgency?: string;
 	budget?: string;
+	lead: LeadFields;
 	instructions?: string;
 	max_tokens?: number;
 };
@@ -77,6 +99,7 @@ type ValidatedChatRequestBody = {
 export interface Env {
 	AI: AiBinding;
 	hello_ai_prod: D1Database;
+	ADMIN_EXPORT_TOKEN?: string;
 }
 
 export type BranchOpsResponse = {
@@ -102,6 +125,7 @@ const ROUTES = {
 	health: "/health",
 	chat: "/chat",
 	analyze: "/analyze",
+	adminExportIntakeLeads: "/admin/export/intake-leads",
 } as const;
 const REQUEST_CONTENT_TYPE = "application/json";
 const INTAKE_MODES = [
@@ -122,6 +146,12 @@ const ANALYZE_ALLOWED_REQUEST_FIELDS = [
 	"audience",
 	"urgency",
 	"budget",
+	"name",
+	"email",
+	"phone",
+	"business_name",
+	"location",
+	"preferred_contact",
 	"instructions",
 	"max_tokens",
 ] as const;
@@ -136,6 +166,14 @@ const CHAT_ALLOWED_REQUEST_FIELDS = [
 const MAX_INPUT_CHARS = 8000;
 const MAX_INSTRUCTIONS_CHARS = 2000;
 const MAX_CONTEXT_FIELD_CHARS = 200;
+const LEAD_FIELD_LIMITS = {
+	name: 120,
+	email: 254,
+	phone: 40,
+	business_name: 160,
+	location: 160,
+	preferred_contact: 80,
+} as const;
 const DEFAULT_MAX_TOKENS = 700;
 const MAX_ALLOWED_TOKENS = 700;
 const MAX_CHAT_TEMPERATURE = 2;
@@ -265,13 +303,29 @@ const CHAT_DEMO_HTML = `<!doctype html>
 			gap: 6px;
 			color: #9fb0c3;
 		}
-		select, textarea {
+		select, textarea, input {
 			width: 100%;
 			padding: 14px;
 			border-radius: 12px;
 			border: 1px solid rgba(148, 163, 184, 0.24);
 			background: #0f172a;
 			color: #e7edf5;
+		}
+		details {
+			border: 1px solid rgba(148, 163, 184, 0.2);
+			border-radius: 12px;
+			padding: 12px;
+			background: rgba(15, 23, 42, 0.52);
+		}
+		summary {
+			cursor: pointer;
+			color: #cbd5e1;
+		}
+		.lead-grid {
+			display: grid;
+			gap: 10px;
+			grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+			margin-top: 12px;
 		}
 		textarea {
 			min-height: 120px;
@@ -331,9 +385,22 @@ const CHAT_DEMO_HTML = `<!doctype html>
 						<option>Compliance / Risk Review</option>
 					</select>
 				</label>
+				<details>
+					<summary>Optional contact info for follow-up</summary>
+					<p class="small">Only add this if you want this intake linked to contact details. Leave it blank for an anonymous draft.</p>
+					<div class="lead-grid">
+						<label>Name<input id="leadName" autocomplete="name" /></label>
+						<label>Email<input id="leadEmail" type="email" autocomplete="email" /></label>
+						<label>Phone<input id="leadPhone" autocomplete="tel" /></label>
+						<label>Business name<input id="leadBusinessName" autocomplete="organization" /></label>
+						<label>Location<input id="leadLocation" autocomplete="address-level2" /></label>
+						<label>Preferred contact<input id="leadPreferredContact" placeholder="email, phone, text..." /></label>
+					</div>
+				</details>
 				<textarea id="messageInput" placeholder="Ask a question, test a workflow, or describe an idea..."></textarea>
 				<div class="actions">
 					<button class="primary" type="submit">Send</button>
+					<button id="analyzeBtn" type="button">Analyze intake</button>
 					<button id="clearBtn" type="button">Clear local chat</button>
 				</div>
 			</form>
@@ -352,7 +419,16 @@ const CHAT_DEMO_HTML = `<!doctype html>
 			var form = document.getElementById('chatForm');
 			var input = document.getElementById('messageInput');
 			var modeSelect = document.getElementById('modeSelect');
+			var analyzeBtn = document.getElementById('analyzeBtn');
 			var clearBtn = document.getElementById('clearBtn');
+			var leadInputs = {
+				name: document.getElementById('leadName'),
+				email: document.getElementById('leadEmail'),
+				phone: document.getElementById('leadPhone'),
+				business_name: document.getElementById('leadBusinessName'),
+				location: document.getElementById('leadLocation'),
+				preferred_contact: document.getElementById('leadPreferredContact')
+			};
 
 			var sessionId = localStorage.getItem(SESSION_KEY) || crypto.randomUUID();
 			localStorage.setItem(SESSION_KEY, sessionId);
@@ -401,6 +477,16 @@ const CHAT_DEMO_HTML = `<!doctype html>
 				chatLog.scrollTop = chatLog.scrollHeight;
 			}
 
+			function collectLeadFields() {
+				return Object.keys(leadInputs).reduce(function (payload, key) {
+					var value = leadInputs[key].value.trim();
+					if (value) {
+						payload[key] = value;
+					}
+					return payload;
+				}, {});
+			}
+
 			async function sendMessage(text) {
 				messages.push({ role: 'user', content: text });
 				render();
@@ -440,6 +526,37 @@ const CHAT_DEMO_HTML = `<!doctype html>
 				persist();
 			}
 
+			async function analyzeMessage(text) {
+				var pending = { role: 'assistant', content: 'Structuring intake...' };
+				messages.push({ role: 'user', content: text });
+				messages.push(pending);
+				render();
+				persist();
+
+				try {
+					var response = await fetch('/analyze', {
+						method: 'POST',
+						headers: { 'Content-Type': 'application/json' },
+						body: JSON.stringify(Object.assign({
+							input: text,
+							mode: modeSelect.value
+						}, collectLeadFields()))
+					});
+
+					var payload = await response.json();
+					if (!response.ok || !payload.ok) {
+						throw new Error(payload.error || 'Analyze request failed.');
+					}
+
+					pending.content = JSON.stringify(payload.data, null, 2);
+				} catch (error) {
+					pending.content = 'Error: ' + (error && error.message ? error.message : 'Unknown error');
+				}
+
+				render();
+				persist();
+			}
+
 			form.addEventListener('submit', function (event) {
 				event.preventDefault();
 				var text = input.value.trim();
@@ -463,6 +580,15 @@ const CHAT_DEMO_HTML = `<!doctype html>
 				];
 				persist();
 				render();
+			});
+
+			analyzeBtn.addEventListener('click', function () {
+				var text = input.value.trim();
+				if (!text) {
+					return;
+				}
+				input.value = '';
+				analyzeMessage(text);
 			});
 
 			render();
@@ -799,6 +925,42 @@ async function persistIntakeEvent(env: Env, event: IntakeEvent): Promise<void> {
 	}
 }
 
+async function persistIntakeLead(
+	env: Env,
+	requestId: string,
+	mode: string,
+	lead: LeadFields,
+): Promise<void> {
+	if (!hasLeadFields(lead)) {
+		return;
+	}
+
+	try {
+		await env.hello_ai_prod.batch([
+			env.hello_ai_prod
+				.prepare(
+					[
+						"INSERT INTO intake_leads",
+						"(request_id, name, email, phone, business_name, location, preferred_contact, mode)",
+						"VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+					].join(" "),
+				)
+				.bind(
+					requestId,
+					lead.name ?? null,
+					lead.email ?? null,
+					lead.phone ?? null,
+					lead.business_name ?? null,
+					lead.location ?? null,
+					lead.preferred_contact ?? null,
+					mode,
+				),
+		]);
+	} catch (error) {
+		console.error("Failed to persist intake lead.", error);
+	}
+}
+
 function queueIntakeEvent(
 	ctx: ExecutionContext,
 	env: Env,
@@ -810,6 +972,16 @@ function queueIntakeEvent(
 			timestamp: new Date().toISOString(),
 		}),
 	);
+}
+
+function queueIntakeLead(
+	ctx: ExecutionContext,
+	env: Env,
+	requestId: string,
+	mode: string,
+	lead: LeadFields,
+): void {
+	ctx.waitUntil(persistIntakeLead(env, requestId, mode, lead));
 }
 
 function getAnalyzeMode(body: Pick<ValidatedAnalyzeRequestBody, "mode">): string {
@@ -895,6 +1067,46 @@ function htmlResponse(html: string, init?: ResponseInit): Response {
 	}
 	headers.set("Content-Type", "text/html; charset=utf-8");
 	return new Response(html, {
+		...init,
+		headers,
+	});
+}
+
+function csvEscape(value: unknown): string {
+	const text = value === null || value === undefined ? "" : String(value);
+	return `"${text.replace(/"/g, '""')}"`;
+}
+
+function csvResponse(
+	rows: LeadExportRow[],
+	requestId: string,
+	init?: ResponseInit,
+): Response {
+	const headers = new Headers(init?.headers);
+	for (const [key, value] of Object.entries(corsHeaders())) {
+		headers.set(key, value);
+	}
+	headers.set("Content-Type", "text/csv; charset=utf-8");
+	headers.set("Content-Disposition", 'attachment; filename="branchops-intake-leads.csv"');
+	headers.set("X-Request-Id", requestId);
+
+	const columns = [
+		"request_id",
+		"name",
+		"email",
+		"phone",
+		"business_name",
+		"location",
+		"preferred_contact",
+		"mode",
+		"created_at",
+	] as const;
+	const lines = [
+		columns.join(","),
+		...rows.map((row) => columns.map((column) => csvEscape(row[column])).join(",")),
+	];
+
+	return new Response(lines.join("\n"), {
 		...init,
 		headers,
 	});
@@ -1085,6 +1297,99 @@ function validateOptionalContextField(
 	return { ok: true, value: text };
 }
 
+function validateLeadTextField(
+	value: unknown,
+	fieldName: keyof LeadFields,
+	route: string,
+	requestId: string,
+): { ok: true; value?: string } | { ok: false; response: Response } {
+	if (value === undefined) {
+		return { ok: true, value: undefined };
+	}
+
+	const text = normalizeString(value);
+	if (!text) {
+		return {
+			ok: false,
+			response: errorResponse(
+				route,
+				400,
+				`'${fieldName}' must be a non-empty string when provided.`,
+				requestId,
+			),
+		};
+	}
+
+	const limit = LEAD_FIELD_LIMITS[fieldName];
+	if (text.length > limit) {
+		return {
+			ok: false,
+			response: errorResponse(
+				route,
+				400,
+				`'${fieldName}' exceeds ${limit} characters.`,
+				requestId,
+			),
+		};
+	}
+
+	return { ok: true, value: text };
+}
+
+function validateEmailField(
+	value: unknown,
+	route: string,
+	requestId: string,
+): { ok: true; value?: string } | { ok: false; response: Response } {
+	const email = validateLeadTextField(value, "email", route, requestId);
+	if (!email.ok || !email.value) {
+		return email;
+	}
+
+	if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email.value)) {
+		return {
+			ok: false,
+			response: errorResponse(
+				route,
+				400,
+				"'email' must be a valid email address when provided.",
+				requestId,
+			),
+		};
+	}
+
+	return email;
+}
+
+function validatePhoneField(
+	value: unknown,
+	route: string,
+	requestId: string,
+): { ok: true; value?: string } | { ok: false; response: Response } {
+	const phone = validateLeadTextField(value, "phone", route, requestId);
+	if (!phone.ok || !phone.value) {
+		return phone;
+	}
+
+	if (!/^[0-9A-Za-z+().\-\s]+$/.test(phone.value)) {
+		return {
+			ok: false,
+			response: errorResponse(
+				route,
+				400,
+				"'phone' contains unsupported characters.",
+				requestId,
+			),
+		};
+	}
+
+	return phone;
+}
+
+function hasLeadFields(lead: LeadFields): boolean {
+	return Object.values(lead).some((value) => Boolean(value));
+}
+
 function validateMaxTokens(
 	value: unknown,
 	route: string,
@@ -1257,6 +1562,56 @@ async function parseAnalyzeRequestBody(
 		return budget;
 	}
 
+	const name = validateLeadTextField(
+		parsed.body.name,
+		"name",
+		ROUTES.analyze,
+		requestId,
+	);
+	if (!name.ok) {
+		return name;
+	}
+
+	const email = validateEmailField(parsed.body.email, ROUTES.analyze, requestId);
+	if (!email.ok) {
+		return email;
+	}
+
+	const phone = validatePhoneField(parsed.body.phone, ROUTES.analyze, requestId);
+	if (!phone.ok) {
+		return phone;
+	}
+
+	const businessName = validateLeadTextField(
+		parsed.body.business_name,
+		"business_name",
+		ROUTES.analyze,
+		requestId,
+	);
+	if (!businessName.ok) {
+		return businessName;
+	}
+
+	const location = validateLeadTextField(
+		parsed.body.location,
+		"location",
+		ROUTES.analyze,
+		requestId,
+	);
+	if (!location.ok) {
+		return location;
+	}
+
+	const preferredContact = validateLeadTextField(
+		parsed.body.preferred_contact,
+		"preferred_contact",
+		ROUTES.analyze,
+		requestId,
+	);
+	if (!preferredContact.ok) {
+		return preferredContact;
+	}
+
 	const instructions = validateInstructions(
 		parsed.body.instructions,
 		ROUTES.analyze,
@@ -1283,6 +1638,14 @@ async function parseAnalyzeRequestBody(
 			audience: audience.value,
 			urgency: urgency.value,
 			budget: budget.value,
+			lead: {
+				name: name.value,
+				email: email.value,
+				phone: phone.value,
+				business_name: businessName.value,
+				location: location.value,
+				preferred_contact: preferredContact.value,
+			},
 			instructions: instructions.value,
 			max_tokens: maxTokens.value,
 		},
@@ -1394,7 +1757,7 @@ async function parseChatRequestBody(
 	};
 }
 
-function handleHealth(requestId: string): Response {
+function handleHealth(requestId: string, env: Env): Response {
 	return jsonResponse({
 		ok: true,
 		status: "ok",
@@ -1408,6 +1771,7 @@ function handleHealth(requestId: string): Response {
 			health: "GET /health",
 			chat: "POST /chat",
 			analyze: "POST /analyze",
+			admin_export_intake_leads: "GET /admin/export/intake-leads",
 		},
 		route_map: [
 			{
@@ -1429,6 +1793,11 @@ function handleHealth(requestId: string): Response {
 				path: ROUTES.analyze,
 				method: "POST",
 				purpose: "Run structured JSON-contract intake analysis.",
+			},
+			{
+				path: ROUTES.adminExportIntakeLeads,
+				method: "GET",
+				purpose: "Export captured intake leads when admin export is configured.",
 			},
 		],
 		request_contracts: {
@@ -1454,6 +1823,12 @@ function handleHealth(requestId: string): Response {
 					"audience",
 					"urgency",
 					"budget",
+					"name",
+					"email",
+					"phone",
+					"business_name",
+					"location",
+					"preferred_contact",
 					"instructions",
 					"max_tokens",
 				],
@@ -1479,9 +1854,21 @@ function handleHealth(requestId: string): Response {
 				],
 			},
 		},
+		lead_capture: {
+			enabled: true,
+			fields: Object.keys(LEAD_FIELD_LIMITS),
+			field_limits: LEAD_FIELD_LIMITS,
+			stores_full_prompt: false,
+		},
+		admin_export: {
+			route: ROUTES.adminExportIntakeLeads,
+			configured: Boolean(env.ADMIN_EXPORT_TOKEN),
+			auth: "Bearer token via ADMIN_EXPORT_TOKEN",
+			content_type: "text/csv",
+		},
 		runtime_requirements: {
 			bindings: ["AI", "hello_ai_prod"],
-			vars: [],
+			vars: ["ADMIN_EXPORT_TOKEN optional for admin export"],
 		},
 		throttle: {
 			routes: [ROUTES.chat, ROUTES.analyze],
@@ -1494,7 +1881,11 @@ function handleHealth(requestId: string): Response {
 
 function handleMethodNotAllowed(pathname: string, requestId: string): Response {
 	const allowedMethod =
-		pathname === ROUTES.root || pathname === ROUTES.health ? "GET" : "POST";
+		pathname === ROUTES.root ||
+		pathname === ROUTES.health ||
+		pathname === ROUTES.adminExportIntakeLeads
+			? "GET"
+			: "POST";
 	return errorResponse(
 		pathname,
 		405,
@@ -1513,11 +1904,75 @@ function handleNotFound(requestId: string): Response {
 				"GET /health",
 				"POST /chat",
 				"POST /analyze",
+				"GET /admin/export/intake-leads",
 			],
 		},
 		requestId,
 		{ status: 404 },
 	);
+}
+
+function getBearerToken(request: Request): string | null {
+	const authorization = request.headers.get("authorization");
+	if (!authorization) {
+		return null;
+	}
+
+	const [scheme, token] = authorization.split(/\s+/, 2);
+	if (scheme?.toLowerCase() !== "bearer" || !token) {
+		return null;
+	}
+
+	return token;
+}
+
+async function handleAdminExportIntakeLeads(
+	request: Request,
+	env: Env,
+	requestId: string,
+): Promise<Response> {
+	if (!env.ADMIN_EXPORT_TOKEN) {
+		return errorResponse(
+			ROUTES.adminExportIntakeLeads,
+			503,
+			"Admin export is not configured.",
+			requestId,
+			{
+				required_env_var: "ADMIN_EXPORT_TOKEN",
+			},
+		);
+	}
+
+	if (getBearerToken(request) !== env.ADMIN_EXPORT_TOKEN) {
+		return errorResponse(
+			ROUTES.adminExportIntakeLeads,
+			401,
+			"Unauthorized.",
+			requestId,
+		);
+	}
+
+	try {
+		const result = await env.hello_ai_prod
+			.prepare(
+				[
+					"SELECT request_id, name, email, phone, business_name, location, preferred_contact, mode, created_at",
+					"FROM intake_leads",
+					"ORDER BY created_at DESC",
+				].join(" "),
+			)
+			.all<LeadExportRow>();
+
+		return csvResponse(result.results ?? [], requestId);
+	} catch (error) {
+		const message = error instanceof Error ? error.message : "Unknown error";
+		return errorResponse(
+			ROUTES.adminExportIntakeLeads,
+			500,
+			message,
+			requestId,
+		);
+	}
 }
 
 export default {
@@ -1537,7 +1992,14 @@ export default {
 		}
 
 		if (request.method === "GET" && url.pathname === ROUTES.health) {
-			return handleHealth(requestId);
+			return handleHealth(requestId, env);
+		}
+
+		if (
+			request.method === "GET" &&
+			url.pathname === ROUTES.adminExportIntakeLeads
+		) {
+			return handleAdminExportIntakeLeads(request, env, requestId);
 		}
 
 		if (request.method === "POST" && url.pathname === ROUTES.chat) {
@@ -1747,6 +2209,13 @@ export default {
 					status: "success",
 					usage: raw.usage ?? null,
 				});
+				queueIntakeLead(
+					ctx,
+					env,
+					requestId,
+					getAnalyzeMode(parsedBody.body),
+					parsedBody.body.lead,
+				);
 
 				return jsonResponse({
 					ok: true,
@@ -1772,7 +2241,8 @@ export default {
 			url.pathname === ROUTES.root ||
 			url.pathname === ROUTES.health ||
 			url.pathname === ROUTES.chat ||
-			url.pathname === ROUTES.analyze
+			url.pathname === ROUTES.analyze ||
+			url.pathname === ROUTES.adminExportIntakeLeads
 		) {
 			return handleMethodNotAllowed(url.pathname, requestId);
 		}

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -13,7 +13,15 @@ type MockDb = D1Database & {
 	statements: RecordedStatement[];
 };
 
-function createDbMock(throwOnBatch = false): MockDb {
+type DbMockOptions = {
+	throwOnBatch?: boolean;
+	throwOnAll?: boolean;
+	leadRows?: Record<string, unknown>[];
+};
+
+function createDbMock(options: boolean | DbMockOptions = false): MockDb {
+	const config: DbMockOptions =
+		typeof options === "boolean" ? { throwOnBatch: options } : options;
 	const statements: RecordedStatement[] = [];
 
 	return {
@@ -21,10 +29,20 @@ function createDbMock(throwOnBatch = false): MockDb {
 			return {
 				bind: (...params: unknown[]) =>
 					({ sql, params }) as unknown as D1PreparedStatement,
+				all: async () => {
+					if (config.throwOnAll) {
+						throw new Error("D1 read failed");
+					}
+					return {
+						results: config.leadRows ?? [],
+						success: true,
+						meta: {},
+					};
+				},
 			} as unknown as D1PreparedStatement;
 		},
 		batch: async (items: readonly D1PreparedStatement[]) => {
-			if (throwOnBatch) {
+			if (config.throwOnBatch) {
 				throw new Error("D1 write failed");
 			}
 			statements.push(...(items as unknown as RecordedStatement[]));
@@ -38,6 +56,7 @@ function createEnv(
 	response: Awaited<ReturnType<Env["AI"]["run"]>>,
 	db: MockDb = createDbMock(),
 	aiRequests: Record<string, unknown>[] = [],
+	overrides: Partial<Env> = {},
 ): Env {
 	return {
 		AI: {
@@ -47,6 +66,7 @@ function createEnv(
 			},
 		},
 		hello_ai_prod: db,
+		...overrides,
 	};
 }
 
@@ -76,6 +96,10 @@ describe("BranchOps AI Intake Worker", () => {
 		expect(html).toContain("Clothing / Brand / IP Asset");
 		expect(html).toContain("Food / Infused Product R&amp;D");
 		expect(html).toContain("Compliance / Risk Review");
+		expect(html).toContain("Optional contact info for follow-up");
+		expect(html).toContain("Business name");
+		expect(html).toContain("Preferred contact");
+		expect(html).toContain("Analyze intake");
 	});
 
 	it("returns an explicit route map on GET /health", async () => {
@@ -100,19 +124,26 @@ describe("BranchOps AI Intake Worker", () => {
 				health: "GET /health",
 				chat: "POST /chat",
 				analyze: "POST /analyze",
+				admin_export_intake_leads: "GET /admin/export/intake-leads",
 			},
 			runtime_requirements: {
 				bindings: ["AI", "hello_ai_prod"],
-				vars: [],
+				vars: ["ADMIN_EXPORT_TOKEN optional for admin export"],
 			},
 		});
-		expect(payload.route_map).toHaveLength(4);
+		expect(payload.route_map).toHaveLength(5);
 		expect(payload.request_contracts.chat.content_type).toBe("application/json");
 		expect(payload.request_contracts.analyze.optional_fields).toEqual([
 			"mode",
 			"audience",
 			"urgency",
 			"budget",
+			"name",
+			"email",
+			"phone",
+			"business_name",
+			"location",
+			"preferred_contact",
 			"instructions",
 			"max_tokens",
 		]);
@@ -135,6 +166,23 @@ describe("BranchOps AI Intake Worker", () => {
 			routes: ["/chat", "/analyze"],
 			limit: 30,
 			window_seconds: 60,
+		});
+		expect(payload.lead_capture).toMatchObject({
+			enabled: true,
+			fields: [
+				"name",
+				"email",
+				"phone",
+				"business_name",
+				"location",
+				"preferred_contact",
+			],
+			stores_full_prompt: false,
+		});
+		expect(payload.admin_export).toMatchObject({
+			route: "/admin/export/intake-leads",
+			configured: false,
+			content_type: "text/csv",
 		});
 	});
 
@@ -323,6 +371,12 @@ describe("BranchOps AI Intake Worker", () => {
 				audience: "solo founder",
 				urgency: "same-day",
 				budget: "lean",
+				name: "Avery Founder",
+				email: "avery@example.com",
+				phone: "+1 555 0100",
+				business_name: "Avery Ops LLC",
+				location: "Detroit, MI",
+				preferred_contact: "email",
 			}),
 		});
 		const ctx = createExecutionContext();
@@ -398,6 +452,7 @@ describe("BranchOps AI Intake Worker", () => {
 		expect(aiRequests[0].input).toContain("Audience: solo founder");
 		expect(aiRequests[0].input).toContain("Urgency: same-day");
 		expect(aiRequests[0].input).toContain("Budget: lean");
+		expect(aiRequests[0].input).not.toContain("avery@example.com");
 		const event = db.statements.find((statement) =>
 			statement.sql.startsWith("INSERT INTO intake_events"),
 		);
@@ -416,6 +471,45 @@ describe("BranchOps AI Intake Worker", () => {
 			null,
 		]);
 		expect(event?.params).not.toContain("Analyze this startup");
+		const lead = db.statements.find((statement) =>
+			statement.sql.startsWith("INSERT INTO intake_leads"),
+		);
+		expect(lead?.params).toEqual([
+			payload.request_id,
+			"Avery Founder",
+			"avery@example.com",
+			"+1 555 0100",
+			"Avery Ops LLC",
+			"Detroit, MI",
+			"email",
+			"Automation Workflow",
+		]);
+		expect(lead?.params).not.toContain("Analyze this startup");
+	});
+
+	it("rejects invalid analyze lead email", async () => {
+		const request = new IncomingRequest("http://example.com/analyze", {
+			method: "POST",
+			headers: {
+				"content-type": "application/json",
+			},
+			body: JSON.stringify({
+				input: "Analyze this startup",
+				email: "not-an-email",
+			}),
+		});
+		const ctx = createExecutionContext();
+		const response = await worker.fetch(request, createEnv({}), ctx);
+
+		await waitOnExecutionContext(ctx);
+		expect(response.status).toBe(400);
+		const payload = await response.json();
+		expectRequestId(payload);
+		expect(payload).toMatchObject({
+			ok: false,
+			error: "'email' must be a valid email address when provided.",
+			route: "/analyze",
+		});
 	});
 
 	it("normalizes common model drift into the public contract", async () => {
@@ -526,7 +620,7 @@ describe("BranchOps AI Intake Worker", () => {
 		});
 	});
 
-	it("keeps analyze behavior working when event logging fails", async () => {
+	it("keeps analyze behavior working when lead persistence fails", async () => {
 		const request = new IncomingRequest("http://example.com/analyze", {
 			method: "POST",
 			headers: {
@@ -536,6 +630,8 @@ describe("BranchOps AI Intake Worker", () => {
 			body: JSON.stringify({
 				input: "Analyze this startup",
 				mode: "Licensing / Royalty Model",
+				name: "Jordan Founder",
+				email: "jordan@example.com",
 			}),
 		});
 		const ctx = createExecutionContext();
@@ -661,6 +757,93 @@ describe("BranchOps AI Intake Worker", () => {
 		});
 	});
 
+	it("returns 503 for admin lead export when token is not configured", async () => {
+		const request = new IncomingRequest(
+			"http://example.com/admin/export/intake-leads",
+		);
+		const ctx = createExecutionContext();
+		const response = await worker.fetch(request, createEnv({}), ctx);
+
+		await waitOnExecutionContext(ctx);
+		expect(response.status).toBe(503);
+		const payload = await response.json();
+		expectRequestId(payload);
+		expect(payload).toMatchObject({
+			ok: false,
+			error: "Admin export is not configured.",
+			route: "/admin/export/intake-leads",
+			required_env_var: "ADMIN_EXPORT_TOKEN",
+		});
+	});
+
+	it("requires bearer token for configured admin lead export", async () => {
+		const request = new IncomingRequest(
+			"http://example.com/admin/export/intake-leads",
+		);
+		const ctx = createExecutionContext();
+		const response = await worker.fetch(
+			request,
+			createEnv({}, createDbMock(), [], { ADMIN_EXPORT_TOKEN: "secret-token" }),
+			ctx,
+		);
+
+		await waitOnExecutionContext(ctx);
+		expect(response.status).toBe(401);
+		const payload = await response.json();
+		expectRequestId(payload);
+		expect(payload).toMatchObject({
+			ok: false,
+			error: "Unauthorized.",
+			route: "/admin/export/intake-leads",
+		});
+	});
+
+	it("exports intake leads as CSV when bearer token is valid", async () => {
+		const request = new IncomingRequest(
+			"http://example.com/admin/export/intake-leads",
+			{
+				headers: {
+					authorization: "Bearer secret-token",
+				},
+			},
+		);
+		const ctx = createExecutionContext();
+		const response = await worker.fetch(
+			request,
+			createEnv(
+				{},
+				createDbMock({
+					leadRows: [
+						{
+							request_id: "req-123",
+							name: "Avery Founder",
+							email: "avery@example.com",
+							phone: "+1 555 0100",
+							business_name: "Avery Ops LLC",
+							location: "Detroit, MI",
+							preferred_contact: "email",
+							mode: "Automation Workflow",
+							created_at: "2026-04-29T00:00:00.000Z",
+						},
+					],
+				}),
+				[],
+				{ ADMIN_EXPORT_TOKEN: "secret-token" },
+			),
+			ctx,
+		);
+
+		await waitOnExecutionContext(ctx);
+		expect(response.status).toBe(200);
+		expect(response.headers.get("content-type")).toContain("text/csv");
+		expect(response.headers.get("x-request-id")).toEqual(expect.any(String));
+		const csv = await response.text();
+		expect(csv).toContain(
+			"request_id,name,email,phone,business_name,location,preferred_contact,mode,created_at",
+		);
+		expect(csv).toContain('"req-123","Avery Founder","avery@example.com"');
+	});
+
 	it("returns 404 on unknown routes", async () => {
 		const request = new IncomingRequest("http://example.com/unknown");
 		const ctx = createExecutionContext();
@@ -678,6 +861,7 @@ describe("BranchOps AI Intake Worker", () => {
 				"GET /health",
 				"POST /chat",
 				"POST /analyze",
+				"GET /admin/export/intake-leads",
 			],
 		});
 	});


### PR DESCRIPTION
## Objective

Add lead capture and export-ready intake records to the BranchOps AI Intake Worker.

## Asset

- Asset Name: BranchOps AI Intake Worker
- Asset ID: BOH-AI-INTAKE-001
- Owner: Branch Off Holdings LLC
- Runtime: Cloudflare Workers + Workers AI + D1

## Changes

- Extended POST `/analyze` with optional lead fields: `name`, `email`, `phone`, `business_name`, `location`, and `preferred_contact`.
- Added validation for optional lead fields, including capped lengths and email format checks.
- Added `intake_leads` D1 schema and indexes.
- Added request-linked lead persistence using `request_id`.
- Added bearer-protected CSV export route for intake leads.
- Added `/health` metadata for lead capture and export configuration.
- Added optional browser lead capture section.
- Updated tests for lead validation, persistence, export auth/config, CSV export, and request ID linkage.
- Updated README, operator SOP, and asset register documentation.

## Validation

- [x] npm run validate — 18 tests passed
- [x] npm run deploy:dry-run
- [x] npm audit — 0 vulnerabilities

## Deployment Notes

- Apply `schema.sql` to D1 before expecting production lead persistence/export.
- Configure `ADMIN_EXPORT_TOKEN` as a Cloudflare secret before enabling export.
- CSV export is intentionally minimal and not a full admin dashboard.

## Risk Controls

- No Airtable secrets added.
- No Notion secrets added.
- No full prompt/private idea content stored by default.
- Export route requires bearer token configuration.