### PR TITLE
Add Airtable lead sync queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ This repository is the public-safe same-day intake Worker for BranchOps asset pl
 | `POST` | `/chat` | Run conversational chat and persist the transcript to D1 | `sessionId`, `reply`, `usage` |
 | `POST` | `/analyze` | Convert a raw idea into a structured BranchOps asset plan | BranchOps planning schema |
 | `GET` | `/admin/export/intake-leads` | Export captured lead records when admin export is configured | Bearer-token protected CSV |
+| `GET` | `/admin/export/sync-queue` | Export lead sync queue records when admin export is configured | Bearer-token protected JSON |
+| `POST` | `/admin/sync/airtable` | Manually sync queued lead records to Airtable | Bearer-token protected JSON summary |
 
 The browser UI is an app-style BranchOps workspace with a desktop sidebar, mobile menu behavior, structured analyzer panel, separate chat lane, lead capture panel, admin export panel, and system health panel.
 
@@ -52,7 +54,7 @@ Planner panels include:
 - prompt helper bullets
 - preselected `/analyze` mode
 
-Operational panels show lead storage boundaries, CSV export requirements, route/capability health cards, and raw `/health` JSON for debugging.
+Operational panels show lead storage boundaries, CSV export requirements, Airtable sync queue metadata, route/capability health cards, and raw `/health` JSON for debugging.
 
 ## Workflow
 
@@ -150,6 +152,7 @@ Supported browser intake modes:
 - route map
 - request contracts
 - runtime requirements
+- safe Airtable sync metadata, including required variable names and route names only
 
 ### Analyze Success
 
@@ -204,9 +207,18 @@ Every JSON response includes `request_id`. `/chat` and `/analyze` use a safe def
 
 The log intentionally does not store full prompt, chat, reply, or idea content by default.
 
-## Lead Capture And Export
+## Lead Capture, Sync Queue, And Export
 
 Optional lead fields on `/analyze` are stored in `intake_leads` only when at least one lead field is provided. The full private prompt is not stored in the lead table.
+
+When an `intake_leads` insert succeeds, the Worker also creates a server-side `lead_sync_queue` row for Airtable:
+
+- `request_id`
+- `destination: airtable`
+- `status: queued`
+- `attempts: 0`
+
+The queue table does not store full prompt content or Airtable secret values. If the queue insert fails, `/analyze` still returns the existing response contract and logs the failure server-side.
 
 `GET /admin/export/intake-leads` returns a CSV export with:
 
@@ -222,6 +234,51 @@ Optional lead fields on `/analyze` are stored in `intake_leads` only when at lea
 
 Admin export is protected by `Authorization: Bearer <token>` when `ADMIN_EXPORT_TOKEN` is configured. If `ADMIN_EXPORT_TOKEN` is missing, the route returns `503` with a safe JSON message explaining that admin export is not configured. No secret is hardcoded in this repo.
 
+`GET /admin/export/sync-queue` returns JSON queue records with the same bearer-token protection.
+
+`POST /admin/sync/airtable` processes a modest batch of queued Airtable records. It reads lead data from `intake_leads` by `request_id`, posts to the Airtable REST API from the Worker runtime, and updates queue rows to `synced` or `error` with a safe `last_error`.
+
+Successful sync responses include:
+
+- `processed`
+- `synced`
+- `failed`
+- `skipped`
+
+No Airtable secret values are exposed in HTML, JSON responses, logs intended for clients, or browser storage.
+
+## Airtable Sync Configuration
+
+Required server variables:
+
+- `ADMIN_EXPORT_TOKEN`
+- `AIRTABLE_API_KEY`
+- `AIRTABLE_BASE_ID`
+- `AIRTABLE_TABLE_NAME`
+
+Configure them as Wrangler secrets:
+
+```powershell
+npx wrangler secret put ADMIN_EXPORT_TOKEN
+npx wrangler secret put AIRTABLE_API_KEY
+npx wrangler secret put AIRTABLE_BASE_ID
+npx wrangler secret put AIRTABLE_TABLE_NAME
+```
+
+Apply the D1 schema locally or remotely as appropriate:
+
+```powershell
+npx wrangler d1 execute hello-ai-prod --file schema.sql --local
+npx wrangler d1 execute hello-ai-prod --file schema.sql --remote
+```
+
+Admin route checks:
+
+```powershell
+curl.exe -H "Authorization: Bearer <ADMIN_EXPORT_TOKEN>" https://<worker-url>/admin/export/sync-queue
+curl.exe -X POST -H "Authorization: Bearer <ADMIN_EXPORT_TOKEN>" https://<worker-url>/admin/sync/airtable
+```
+
 ## Environment Requirements
 
 Runtime bindings:
@@ -235,6 +292,7 @@ D1 schema:
 - `chat_messages`
 - `intake_events`
 - `intake_leads`
+- `lead_sync_queue`
 
 Operator requirements:
 
@@ -281,6 +339,8 @@ curl.exe https://<worker-url>/
 curl.exe https://<worker-url>/health
 curl.exe -X POST https://<worker-url>/chat -H "content-type: application/json" --data "{\"sessionId\":\"demo-session-001\",\"messages\":[{\"role\":\"user\",\"content\":\"How should this idea become an asset?\"}]}"
 curl.exe -X POST https://<worker-url>/analyze -H "content-type: application/json" --data "{\"input\":\"Turn this founder idea into a structured BranchOps asset plan.\"}"
+curl.exe -H "Authorization: Bearer <ADMIN_EXPORT_TOKEN>" https://<worker-url>/admin/export/sync-queue
+curl.exe -X POST -H "Authorization: Bearer <ADMIN_EXPORT_TOKEN>" https://<worker-url>/admin/sync/airtable
 ```
 
 ## Boundary Rules
@@ -288,6 +348,9 @@ curl.exe -X POST https://<worker-url>/analyze -H "content-type: application/json
 - Keep internal business logic, private operating records, and sensitive production credentials out of this repository.
 - Treat this repo as a public-safe BranchOps intake surface.
 - Do not let intake scope drift into the primary system-of-record lane.
+- Keep Airtable API keys, base IDs, table names, and admin tokens server-side.
+- Do not ask users to enter Airtable secrets in the browser.
+- Do not store admin tokens or Airtable secrets in `localStorage`.
 
 ## System Of Record
 

--- a/docs/ASSET_REGISTER.md
+++ b/docs/ASSET_REGISTER.md
@@ -16,11 +16,25 @@ The current intake modes cover business assets, royalty models, automation workf
 
 Optional lead capture supports follow-up workflows when a submitter chooses to provide contact details. Captured lead records are export-ready through a bearer-token protected CSV route when `ADMIN_EXPORT_TOKEN` is configured.
 
+The Airtable Lead Sync Queue adds a controlled CRM bridge: leads are stored in D1 first, queued server-side in `lead_sync_queue`, and manually synced to Airtable through an admin-token protected Worker route. This improves revenue operations by reducing manual CSV handoff while preserving the public-safe Worker boundary.
+
 The browser surface now presents the asset as an app-style BranchOps workspace with visible feature navigation, mode-specific planner panels, recommended use cases, prompt helpers, result cards, lead capture, export/admin status, and health visibility.
 
 ## Licensing Potential
 
 The structured intake contract can become a licensable module for founder studios, operators, agencies, and business formation workflows that need repeatable idea-to-asset planning.
+
+## Asset Layers
+
+| Layer | Value |
+| --- | --- |
+| BranchOps AI Intake Worker | Public-safe idea-to-asset intake and chat surface |
+| D1 Event And Lead Store | Request metadata, voluntary lead fields, and export-ready operational records |
+| Airtable Lead Sync Queue | Server-side queue for controlled CRM sync without exposing Airtable secrets to the browser |
+
+## CRM And Revenue Value
+
+The Airtable Lead Sync Queue supports follow-up speed, CRM hygiene, and revenue attribution. It lets operators move qualified inquiries from D1 into Airtable without asking browser users for admin tokens or Airtable credentials.
 
 ## Compliance Notes
 
@@ -30,6 +44,10 @@ The structured intake contract can become a licensable module for founder studio
 - Do not hardcode secrets or private BranchOps operating records in this repository.
 - Structured D1 logs should store request metadata, status, token usage, and error details only; do not store full idea, chat, or reply content by default.
 - `intake_leads` may contain personal contact data when submitted voluntarily; export access must stay token-protected and the token must be stored as a Cloudflare secret.
+- `lead_sync_queue` stores queue metadata only: request ID, destination, status, attempts, safe error text, and timestamps. It must not store full prompt content or Airtable secret values.
+- Airtable API keys, base IDs, table names, and admin export tokens must stay in Worker environment secrets or equivalent server-side configuration.
+- Browser UI must not request, display, persist, or transmit Airtable secrets. Do not store admin tokens or Airtable credentials in localStorage.
+- Manual Airtable sync is protected by `ADMIN_EXPORT_TOKEN` and returns only safe summary metadata.
 - Basic per-IP throttling is an abuse-control guardrail, not a substitute for authenticated platform-level rate limits.
 
 ## Promotion Path Into BranchOps Platform
@@ -37,7 +55,8 @@ The structured intake contract can become a licensable module for founder studio
 1. Prove the public-safe intake schema through this Worker.
 2. Use `request_id` and `intake_events` to trace public-safe route behavior.
 3. Use `intake_leads` CSV export as the temporary bridge into manual review.
-4. Use the sidebar workspace as the public-safe preview of future BranchOps Platform navigation.
-5. Add authenticated intake capture and review queues in the internal BranchOps Platform.
-6. Promote qualified plans into asset records, task workflows, and owner dashboards.
-7. Add reporting for conversion, revenue attribution, licensing candidates, and compliance review status.
+4. Use `lead_sync_queue` and the Airtable sync route as the controlled CRM bridge.
+5. Use the sidebar workspace as the public-safe preview of future BranchOps Platform navigation.
+6. Add authenticated intake capture and review queues in the internal BranchOps Platform.
+7. Promote qualified plans into asset records, task workflows, and owner dashboards.
+8. Add reporting for conversion, revenue attribution, licensing candidates, and compliance review status.

--- a/docs/CODEX_OPERATOR_SOP.md
+++ b/docs/CODEX_OPERATOR_SOP.md
@@ -16,8 +16,23 @@ npm install
 ```
 
 4. Confirm Cloudflare access is available through `wrangler login` or a scoped `CLOUDFLARE_API_TOKEN`.
-5. Confirm the D1 database has the current schema from `schema.sql`, including `intake_events` and `intake_leads`, before expecting structured event logs or lead export.
-6. Configure `ADMIN_EXPORT_TOKEN` as a Cloudflare secret only when admin CSV export should be enabled. Do not commit or hardcode the token.
+5. Confirm the D1 database has the current schema from `schema.sql`, including `intake_events`, `intake_leads`, and `lead_sync_queue`, before expecting structured event logs, lead export, or Airtable queue sync.
+6. Configure `ADMIN_EXPORT_TOKEN` as a Cloudflare secret when admin CSV export or Airtable sync should be enabled. Do not commit or hardcode the token.
+7. Configure Airtable sync server variables only in the Worker environment. Do not place Airtable keys in browser code, localStorage, README examples with real values, or committed config.
+
+```powershell
+npx wrangler secret put ADMIN_EXPORT_TOKEN
+npx wrangler secret put AIRTABLE_API_KEY
+npx wrangler secret put AIRTABLE_BASE_ID
+npx wrangler secret put AIRTABLE_TABLE_NAME
+```
+
+Apply the D1 schema before testing lead queue behavior:
+
+```powershell
+npx wrangler d1 execute hello-ai-prod --file schema.sql --local
+npx wrangler d1 execute hello-ai-prod --file schema.sql --remote
+```
 
 ## Local Dev
 
@@ -45,6 +60,7 @@ Manual UI checks:
 - Analyze intake renders result cards for objective, classification, asset, execution_plan, systems, monetization_model, automation_opportunities, legal_compliance_risks, scaling_path, and long_term_value.
 - Lead Capture lists optional fields, what is stored, what is not stored, and the request_id linkage.
 - Export / Admin lists CSV fields and a safe curl example with an ADMIN_EXPORT_TOKEN placeholder only.
+- Export / Admin lists the Airtable Sync Queue, `GET /admin/export/sync-queue`, `POST /admin/sync/airtable`, required server vars, and the no-browser-secrets boundary.
 - System Health fetches `/health` without requiring secrets.
 - System Health renders readable capability cards plus expandable raw JSON.
 
@@ -53,10 +69,11 @@ Manual UI checks:
 Run the full project validation:
 
 ```powershell
+npm run build
 npm run validate
 ```
 
-This runs TypeScript build checks and the Vitest suite.
+`npm run validate` runs TypeScript build checks and the Vitest suite.
 
 Review dependency audit output separately:
 
@@ -91,15 +108,27 @@ Confirm:
 - `/analyze` accepts optional lead fields and rejects malformed email values.
 - `/chat` and `/analyze` create public-safe `intake_events` rows without storing full content.
 - lead submissions create `intake_leads` rows linked by `request_id` without storing full prompt content.
+- lead submissions create `lead_sync_queue` rows with `destination = airtable`, `status = queued`, and no full prompt content.
 - `GET /admin/export/intake-leads` returns `503` until `ADMIN_EXPORT_TOKEN` is configured.
+- `GET /admin/export/sync-queue` returns `503` until `ADMIN_EXPORT_TOKEN` is configured and `401` with a missing or invalid bearer token.
+- `POST /admin/sync/airtable` returns `503` with `Airtable sync is not configured.` until Airtable server variables are configured.
+- `POST /admin/sync/airtable` returns a JSON summary with `processed`, `synced`, `failed`, and `skipped` when configured.
 - Throttled requests return `429` with `request_id`.
+
+Admin sync verification commands:
+
+```powershell
+curl.exe -H "Authorization: Bearer <ADMIN_EXPORT_TOKEN>" https://<worker-url>/admin/export/sync-queue
+curl.exe -X POST -H "Authorization: Bearer <ADMIN_EXPORT_TOKEN>" https://<worker-url>/admin/sync/airtable
+```
 
 ## Rollback
 
 1. Identify the previous good deployment in Cloudflare Workers deployments.
 2. Use the Cloudflare dashboard rollback flow or the current Wrangler rollback command supported by the account.
 3. Verify `GET /health` and route behavior after rollback.
-4. Open a follow-up issue or commit with the failed deployment notes.
+4. If rolling back the Airtable sync layer, leave the D1 `lead_sync_queue` table in place unless a separate data-retention decision is approved; removing the table is not required to restore prior route behavior.
+5. Open a follow-up issue or commit with the failed deployment notes.
 
 ## Git Workflow
 
@@ -119,11 +148,11 @@ git status
 
 ```powershell
 git add README.md docs/CODEX_OPERATOR_SOP.md docs/ASSET_REGISTER.md schema.sql src/index.ts test/index.spec.ts
-git commit -m "Add BranchOps sidebar feature navigation"
+git commit -m "add Airtable lead sync queue"
 ```
 
 5. Push the active branch:
 
 ```powershell
-git push origin HEAD
+git push -u origin codex/airtable-lead-sync-queue
 ```

--- a/schema.sql
+++ b/schema.sql
@@ -58,3 +58,26 @@ ON intake_leads(request_id);
 
 CREATE INDEX IF NOT EXISTS idx_intake_leads_created_at
 ON intake_leads(created_at);
+
+CREATE TABLE IF NOT EXISTS lead_sync_queue (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  request_id TEXT NOT NULL,
+  destination TEXT NOT NULL DEFAULT 'airtable',
+  status TEXT NOT NULL DEFAULT 'queued',
+  attempts INTEGER NOT NULL DEFAULT 0,
+  last_error TEXT,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_lead_sync_queue_request_id
+ON lead_sync_queue(request_id);
+
+CREATE INDEX IF NOT EXISTS idx_lead_sync_queue_destination
+ON lead_sync_queue(destination);
+
+CREATE INDEX IF NOT EXISTS idx_lead_sync_queue_status
+ON lead_sync_queue(status);
+
+CREATE INDEX IF NOT EXISTS idx_lead_sync_queue_created_at
+ON lead_sync_queue(created_at);

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,6 +77,30 @@ type LeadExportRow = LeadFields & {
 	created_at: string;
 };
 
+type LeadSyncQueueRecord = {
+	id: number;
+	request_id: string;
+	destination: string;
+	status: string;
+	attempts: number;
+	last_error: string | null;
+	created_at: string;
+	updated_at: string;
+};
+
+type AirtableLeadSyncRow = LeadSyncQueueRecord &
+	LeadFields & {
+		mode: string | null;
+		lead_created_at: string | null;
+	};
+
+type AirtableSyncSummary = {
+	processed: number;
+	synced: number;
+	failed: number;
+	skipped: number;
+};
+
 type ValidatedAnalyzeRequestBody = {
 	input: string;
 	mode?: string;
@@ -100,6 +124,9 @@ export interface Env {
 	AI: AiBinding;
 	hello_ai_prod: D1Database;
 	ADMIN_EXPORT_TOKEN?: string;
+	AIRTABLE_API_KEY?: string;
+	AIRTABLE_BASE_ID?: string;
+	AIRTABLE_TABLE_NAME?: string;
 }
 
 export type BranchOpsResponse = {
@@ -126,6 +153,8 @@ const ROUTES = {
 	chat: "/chat",
 	analyze: "/analyze",
 	adminExportIntakeLeads: "/admin/export/intake-leads",
+	adminExportSyncQueue: "/admin/export/sync-queue",
+	adminSyncAirtable: "/admin/sync/airtable",
 } as const;
 const REQUEST_CONTENT_TYPE = "application/json";
 const INTAKE_MODES = [
@@ -174,6 +203,13 @@ const LEAD_FIELD_LIMITS = {
 	location: 160,
 	preferred_contact: 80,
 } as const;
+const AIRTABLE_DESTINATION = "airtable";
+const AIRTABLE_SYNC_BATCH_LIMIT = 10;
+const AIRTABLE_REQUIRED_ENV_VARS = [
+	"AIRTABLE_API_KEY",
+	"AIRTABLE_BASE_ID",
+	"AIRTABLE_TABLE_NAME",
+] as const;
 const DEFAULT_MAX_TOKENS = 700;
 const MAX_ALLOWED_TOKENS = 700;
 const MAX_CHAT_TEMPERATURE = 2;
@@ -811,7 +847,17 @@ const CHAT_DEMO_HTML = `<!doctype html>
 						<div class="route-item"><strong>CSV fields</strong><br />request_id, name, email, phone, business_name, location, preferred_contact, mode, created_at</div>
 						<div class="route-item"><strong>Missing token</strong><br />503 admin export is not configured</div>
 					</div>
-					<div class="panel">
+					<div class="callout">
+						<strong>Airtable Sync Queue</strong>
+						<p class="muted">Leads are stored in D1 first. The sync queue is server-side, no Airtable secrets are stored in the browser, and manual sync is admin-token protected.</p>
+					</div>
+					<div class="route-list">
+						<div class="route-item"><strong>Queue route</strong><br /><code>GET /admin/export/sync-queue</code></div>
+						<div class="route-item"><strong>Sync route</strong><br /><code>POST /admin/sync/airtable</code></div>
+						<div class="route-item"><strong>Required server vars</strong><br /><code>AIRTABLE_API_KEY</code>, <code>AIRTABLE_BASE_ID</code>, <code>AIRTABLE_TABLE_NAME</code>, <code>ADMIN_EXPORT_TOKEN</code></div>
+						<div class="route-item"><strong>Secrets boundary</strong><br />Airtable keys stay in Worker environment secrets and are never requested by this browser UI.</div>
+					</div>
+					<div class="callout">
 						<h3>Safe curl example</h3>
 						<pre>curl.exe -H "Authorization: Bearer &lt;ADMIN_EXPORT_TOKEN&gt;" https://&lt;worker-url&gt;/admin/export/intake-leads</pre>
 					</div>
@@ -827,6 +873,7 @@ const CHAT_DEMO_HTML = `<!doctype html>
 					<div id="healthCards" class="health-grid">
 						<div class="route-item"><strong>Status</strong><br /><span id="healthStatus">Not loaded</span></div>
 						<div class="route-item"><strong>Admin export</strong><br /><span id="healthExport">Not loaded</span></div>
+						<div class="route-item"><strong>Airtable sync</strong><br /><span id="healthAirtableSync">Not loaded</span></div>
 						<div class="route-item"><strong>Routes</strong><br /><span id="healthRouteCount">Not loaded</span></div>
 					</div>
 					<div id="healthRoutes" class="route-list"></div>
@@ -928,6 +975,7 @@ const CHAT_DEMO_HTML = `<!doctype html>
 			var dashboardRoutes = document.getElementById('dashboardRoutes');
 			var healthStatus = document.getElementById('healthStatus');
 			var healthExport = document.getElementById('healthExport');
+			var healthAirtableSync = document.getElementById('healthAirtableSync');
 			var healthRouteCount = document.getElementById('healthRouteCount');
 			var healthRoutes = document.getElementById('healthRoutes');
 			var healthOutput = document.getElementById('healthOutput');
@@ -1093,7 +1141,7 @@ const CHAT_DEMO_HTML = `<!doctype html>
 					var descMap = {
 						dashboard: 'A public-safe intake workspace for turning raw ideas into structured BranchOps asset plans.',
 						lead: 'Optional follow-up fields connect request IDs to export-ready lead records.',
-						admin: 'CSV export route metadata without exposing admin credentials.',
+						admin: 'CSV export and Airtable sync metadata without exposing admin credentials.',
 						health: 'Route and capability metadata from the Worker health endpoint.'
 					};
 					activeTitle.textContent = titleMap[panel];
@@ -1191,6 +1239,7 @@ const CHAT_DEMO_HTML = `<!doctype html>
 				var routes = body && body.routes ? Object.keys(body.routes) : [];
 				healthStatus.textContent = body && body.status ? body.status : 'unknown';
 				healthExport.textContent = body && body.admin_export && body.admin_export.configured ? 'Configured' : 'Not configured';
+				healthAirtableSync.textContent = body && body.airtable_sync && body.airtable_sync.configured ? 'Configured' : 'Not configured';
 				healthRouteCount.textContent = String(routes.length);
 				exportConfiguredStatus.textContent = body && body.admin_export && body.admin_export.configured ? 'Yes' : 'No';
 				intakeModeCount.textContent = body && body.request_contracts && body.request_contracts.analyze ? String(body.request_contracts.analyze.intake_modes.length) : '10';
@@ -1636,8 +1685,30 @@ async function persistIntakeLead(
 					mode,
 				),
 		]);
+		await persistLeadSyncQueueItem(env, requestId);
 	} catch (error) {
 		console.error("Failed to persist intake lead.", error);
+	}
+}
+
+async function persistLeadSyncQueueItem(
+	env: Env,
+	requestId: string,
+): Promise<void> {
+	try {
+		await env.hello_ai_prod.batch([
+			env.hello_ai_prod
+				.prepare(
+					[
+						"INSERT INTO lead_sync_queue",
+						"(request_id, destination, status, attempts)",
+						"VALUES (?, ?, ?, ?)",
+					].join(" "),
+				)
+				.bind(requestId, AIRTABLE_DESTINATION, "queued", 0),
+		]);
+	} catch (error) {
+		console.error("Failed to enqueue Airtable lead sync.", error);
 	}
 }
 
@@ -2452,6 +2523,8 @@ function handleHealth(requestId: string, env: Env): Response {
 			chat: "POST /chat",
 			analyze: "POST /analyze",
 			admin_export_intake_leads: "GET /admin/export/intake-leads",
+			admin_export_sync_queue: "GET /admin/export/sync-queue",
+			admin_sync_airtable: "POST /admin/sync/airtable",
 		},
 		route_map: [
 			{
@@ -2478,6 +2551,16 @@ function handleHealth(requestId: string, env: Env): Response {
 				path: ROUTES.adminExportIntakeLeads,
 				method: "GET",
 				purpose: "Export captured intake leads when admin export is configured.",
+			},
+			{
+				path: ROUTES.adminExportSyncQueue,
+				method: "GET",
+				purpose: "Export server-side lead sync queue records when admin export is configured.",
+			},
+			{
+				path: ROUTES.adminSyncAirtable,
+				method: "POST",
+				purpose: "Manually sync queued lead records to Airtable from the Worker runtime.",
 			},
 		],
 		request_contracts: {
@@ -2539,6 +2622,7 @@ function handleHealth(requestId: string, env: Env): Response {
 			fields: Object.keys(LEAD_FIELD_LIMITS),
 			field_limits: LEAD_FIELD_LIMITS,
 			stores_full_prompt: false,
+			sync_queue_destination: AIRTABLE_DESTINATION,
 		},
 		admin_export: {
 			route: ROUTES.adminExportIntakeLeads,
@@ -2546,9 +2630,24 @@ function handleHealth(requestId: string, env: Env): Response {
 			auth: "Bearer token via ADMIN_EXPORT_TOKEN",
 			content_type: "text/csv",
 		},
+		airtable_sync: {
+			enabled: true,
+			configured: isAirtableSyncConfigured(env),
+			required_vars: AIRTABLE_REQUIRED_ENV_VARS,
+			routes: {
+				queue_export: "GET /admin/export/sync-queue",
+				manual_sync: "POST /admin/sync/airtable",
+			},
+			destination: AIRTABLE_DESTINATION,
+		},
 		runtime_requirements: {
 			bindings: ["AI", "hello_ai_prod"],
-			vars: ["ADMIN_EXPORT_TOKEN optional for admin export"],
+			vars: [
+				"ADMIN_EXPORT_TOKEN optional for admin export",
+				"AIRTABLE_API_KEY optional for Airtable sync",
+				"AIRTABLE_BASE_ID optional for Airtable sync",
+				"AIRTABLE_TABLE_NAME optional for Airtable sync",
+			],
 		},
 		throttle: {
 			routes: [ROUTES.chat, ROUTES.analyze],
@@ -2563,7 +2662,8 @@ function handleMethodNotAllowed(pathname: string, requestId: string): Response {
 	const allowedMethod =
 		pathname === ROUTES.root ||
 		pathname === ROUTES.health ||
-		pathname === ROUTES.adminExportIntakeLeads
+		pathname === ROUTES.adminExportIntakeLeads ||
+		pathname === ROUTES.adminExportSyncQueue
 			? "GET"
 			: "POST";
 	return errorResponse(
@@ -2585,6 +2685,8 @@ function handleNotFound(requestId: string): Response {
 				"POST /chat",
 				"POST /analyze",
 				"GET /admin/export/intake-leads",
+				"GET /admin/export/sync-queue",
+				"POST /admin/sync/airtable",
 			],
 		},
 		requestId,
@@ -2606,14 +2708,15 @@ function getBearerToken(request: Request): string | null {
 	return token;
 }
 
-async function handleAdminExportIntakeLeads(
+function getAdminAuthorizationError(
 	request: Request,
 	env: Env,
+	route: string,
 	requestId: string,
-): Promise<Response> {
+): Response | null {
 	if (!env.ADMIN_EXPORT_TOKEN) {
 		return errorResponse(
-			ROUTES.adminExportIntakeLeads,
+			route,
 			503,
 			"Admin export is not configured.",
 			requestId,
@@ -2624,12 +2727,41 @@ async function handleAdminExportIntakeLeads(
 	}
 
 	if (getBearerToken(request) !== env.ADMIN_EXPORT_TOKEN) {
-		return errorResponse(
-			ROUTES.adminExportIntakeLeads,
-			401,
-			"Unauthorized.",
-			requestId,
-		);
+		return errorResponse(route, 401, "Unauthorized.", requestId);
+	}
+
+	return null;
+}
+
+function getMissingAirtableEnvVars(env: Env): string[] {
+	return AIRTABLE_REQUIRED_ENV_VARS.filter((name) => {
+		if (name === "AIRTABLE_API_KEY") {
+			return !env.AIRTABLE_API_KEY;
+		}
+		if (name === "AIRTABLE_BASE_ID") {
+			return !env.AIRTABLE_BASE_ID;
+		}
+		return !env.AIRTABLE_TABLE_NAME;
+	});
+}
+
+function isAirtableSyncConfigured(env: Env): boolean {
+	return getMissingAirtableEnvVars(env).length === 0;
+}
+
+async function handleAdminExportIntakeLeads(
+	request: Request,
+	env: Env,
+	requestId: string,
+): Promise<Response> {
+	const authError = getAdminAuthorizationError(
+		request,
+		env,
+		ROUTES.adminExportIntakeLeads,
+		requestId,
+	);
+	if (authError) {
+		return authError;
 	}
 
 	try {
@@ -2650,6 +2782,221 @@ async function handleAdminExportIntakeLeads(
 			ROUTES.adminExportIntakeLeads,
 			500,
 			message,
+			requestId,
+		);
+	}
+}
+
+async function handleAdminExportSyncQueue(
+	request: Request,
+	env: Env,
+	requestId: string,
+): Promise<Response> {
+	const authError = getAdminAuthorizationError(
+		request,
+		env,
+		ROUTES.adminExportSyncQueue,
+		requestId,
+	);
+	if (authError) {
+		return authError;
+	}
+
+	try {
+		const result = await env.hello_ai_prod
+			.prepare(
+				[
+					"SELECT id, request_id, destination, status, attempts, last_error, created_at, updated_at",
+					"FROM lead_sync_queue",
+					"ORDER BY created_at DESC",
+				].join(" "),
+			)
+			.all<LeadSyncQueueRecord>();
+
+		return jsonResponse(
+			{
+				ok: true,
+				data: {
+					records: result.results ?? [],
+				},
+			},
+			requestId,
+		);
+	} catch (error) {
+		console.error("Failed to export sync queue.", error);
+		return errorResponse(
+			ROUTES.adminExportSyncQueue,
+			500,
+			"Sync queue export failed.",
+			requestId,
+		);
+	}
+}
+
+async function getQueuedAirtableSyncRows(env: Env): Promise<AirtableLeadSyncRow[]> {
+	const result = await env.hello_ai_prod
+		.prepare(
+			[
+				"SELECT",
+				"q.id, q.request_id, q.destination, q.status, q.attempts, q.last_error, q.created_at, q.updated_at,",
+				"l.name, l.email, l.phone, l.business_name, l.location, l.preferred_contact, l.mode, l.created_at AS lead_created_at",
+				"FROM lead_sync_queue q",
+				"LEFT JOIN intake_leads l ON l.request_id = q.request_id",
+				"WHERE q.destination = ? AND q.status = ?",
+				"ORDER BY q.created_at ASC",
+				"LIMIT ?",
+			].join(" "),
+		)
+		.bind(AIRTABLE_DESTINATION, "queued", AIRTABLE_SYNC_BATCH_LIMIT)
+		.all<AirtableLeadSyncRow>();
+
+	return result.results ?? [];
+}
+
+function buildAirtablePayload(rows: AirtableLeadSyncRow[]): Record<string, unknown> {
+	return {
+		records: rows.map((row) => ({
+			fields: {
+				"Request ID": row.request_id,
+				Name: row.name ?? "",
+				Email: row.email ?? "",
+				Phone: row.phone ?? "",
+				"Business Name": row.business_name ?? "",
+				Location: row.location ?? "",
+				"Preferred Contact": row.preferred_contact ?? "",
+				Mode: row.mode ?? "",
+				"Created At": row.lead_created_at ?? row.created_at,
+			},
+		})),
+	};
+}
+
+async function updateLeadSyncQueueStatus(
+	env: Env,
+	ids: number[],
+	status: "synced" | "error",
+	lastError: string | null,
+): Promise<void> {
+	if (ids.length === 0) {
+		return;
+	}
+
+	const updatedAt = new Date().toISOString();
+	await env.hello_ai_prod.batch(
+		ids.map((id) =>
+			env.hello_ai_prod
+				.prepare(
+					"UPDATE lead_sync_queue SET status = ?, attempts = attempts + 1, last_error = ?, updated_at = ? WHERE id = ?",
+				)
+				.bind(status, lastError, updatedAt, id),
+		),
+	);
+}
+
+async function handleAdminSyncAirtable(
+	request: Request,
+	env: Env,
+	requestId: string,
+): Promise<Response> {
+	const authError = getAdminAuthorizationError(
+		request,
+		env,
+		ROUTES.adminSyncAirtable,
+		requestId,
+	);
+	if (authError) {
+		return authError;
+	}
+
+	const missingEnvVars = getMissingAirtableEnvVars(env);
+	if (missingEnvVars.length > 0) {
+		return errorResponse(
+			ROUTES.adminSyncAirtable,
+			503,
+			"Airtable sync is not configured.",
+			requestId,
+			{
+				required_env_vars: AIRTABLE_REQUIRED_ENV_VARS,
+				missing_env_vars: missingEnvVars,
+			},
+		);
+	}
+
+	const summary: AirtableSyncSummary = {
+		processed: 0,
+		synced: 0,
+		failed: 0,
+		skipped: 0,
+	};
+
+	try {
+		const rows = await getQueuedAirtableSyncRows(env);
+		summary.processed = rows.length;
+
+		const missingLeadRows = rows.filter((row) => !row.lead_created_at);
+		if (missingLeadRows.length > 0) {
+			await updateLeadSyncQueueStatus(
+				env,
+				missingLeadRows.map((row) => row.id),
+				"error",
+				"No matching intake_leads record.",
+			);
+			summary.skipped = missingLeadRows.length;
+		}
+
+		const syncRows = rows.filter((row) => row.lead_created_at);
+		if (syncRows.length === 0) {
+			return jsonResponse({ ok: true, data: { summary } }, requestId);
+		}
+
+		const airtableUrl = `https://api.airtable.com/v0/${encodeURIComponent(
+			env.AIRTABLE_BASE_ID!,
+		)}/${encodeURIComponent(env.AIRTABLE_TABLE_NAME!)}`;
+		const airtablePayload = buildAirtablePayload(syncRows);
+		const syncRowIds = syncRows.map((row) => row.id);
+
+		let airtableResponse: Response;
+		try {
+			airtableResponse = await fetch(airtableUrl, {
+				method: "POST",
+				headers: {
+					Authorization: `Bearer ${env.AIRTABLE_API_KEY}`,
+					"Content-Type": REQUEST_CONTENT_TYPE,
+				},
+				body: JSON.stringify(airtablePayload),
+			});
+		} catch (error) {
+			console.error("Airtable sync request failed.", error);
+			await updateLeadSyncQueueStatus(
+				env,
+				syncRowIds,
+				"error",
+				"Airtable API request failed.",
+			);
+			summary.failed = syncRows.length;
+			return jsonResponse({ ok: true, data: { summary } }, requestId);
+		}
+
+		if (!airtableResponse.ok) {
+			await updateLeadSyncQueueStatus(
+				env,
+				syncRowIds,
+				"error",
+				`Airtable API returned HTTP ${airtableResponse.status}.`,
+			);
+			summary.failed = syncRows.length;
+			return jsonResponse({ ok: true, data: { summary } }, requestId);
+		}
+
+		await updateLeadSyncQueueStatus(env, syncRowIds, "synced", null);
+		summary.synced = syncRows.length;
+		return jsonResponse({ ok: true, data: { summary } }, requestId);
+	} catch (error) {
+		console.error("Airtable sync failed.", error);
+		return errorResponse(
+			ROUTES.adminSyncAirtable,
+			500,
+			"Airtable sync failed.",
 			requestId,
 		);
 	}
@@ -2680,6 +3027,17 @@ export default {
 			url.pathname === ROUTES.adminExportIntakeLeads
 		) {
 			return handleAdminExportIntakeLeads(request, env, requestId);
+		}
+
+		if (
+			request.method === "GET" &&
+			url.pathname === ROUTES.adminExportSyncQueue
+		) {
+			return handleAdminExportSyncQueue(request, env, requestId);
+		}
+
+		if (request.method === "POST" && url.pathname === ROUTES.adminSyncAirtable) {
+			return handleAdminSyncAirtable(request, env, requestId);
 		}
 
 		if (request.method === "POST" && url.pathname === ROUTES.chat) {
@@ -2922,7 +3280,9 @@ export default {
 			url.pathname === ROUTES.health ||
 			url.pathname === ROUTES.chat ||
 			url.pathname === ROUTES.analyze ||
-			url.pathname === ROUTES.adminExportIntakeLeads
+			url.pathname === ROUTES.adminExportIntakeLeads ||
+			url.pathname === ROUTES.adminExportSyncQueue ||
+			url.pathname === ROUTES.adminSyncAirtable
 		) {
 			return handleMethodNotAllowed(url.pathname, requestId);
 		}

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -1,5 +1,5 @@
 import { createExecutionContext, waitOnExecutionContext } from "cloudflare:test";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import worker, { type Env } from "../src/index";
 
 const IncomingRequest = Request<unknown, IncomingRequestCfProperties>;
@@ -17,6 +17,8 @@ type DbMockOptions = {
 	throwOnBatch?: boolean;
 	throwOnAll?: boolean;
 	leadRows?: Record<string, unknown>[];
+	queueRows?: Record<string, unknown>[];
+	syncRows?: Record<string, unknown>[];
 };
 
 function createDbMock(options: boolean | DbMockOptions = false): MockDb {
@@ -24,14 +26,31 @@ function createDbMock(options: boolean | DbMockOptions = false): MockDb {
 		typeof options === "boolean" ? { throwOnBatch: options } : options;
 	const statements: RecordedStatement[] = [];
 
-	return {
-		prepare(sql: string) {
-			return {
-				bind: (...params: unknown[]) =>
-					({ sql, params }) as unknown as D1PreparedStatement,
-				all: async () => {
+	const statement = (
+		sql: string,
+		params: unknown[] = [],
+	): D1PreparedStatement & RecordedStatement => {
+		return {
+			sql,
+			params,
+			bind: (...boundParams: unknown[]) => statement(sql, boundParams),
+			all: async () => {
 					if (config.throwOnAll) {
 						throw new Error("D1 read failed");
+					}
+					if (sql.includes("FROM lead_sync_queue q")) {
+						return {
+							results: config.syncRows ?? [],
+							success: true,
+							meta: {},
+						};
+					}
+					if (sql.includes("FROM lead_sync_queue")) {
+						return {
+							results: config.queueRows ?? [],
+							success: true,
+							meta: {},
+						};
 					}
 					return {
 						results: config.leadRows ?? [],
@@ -39,13 +58,23 @@ function createDbMock(options: boolean | DbMockOptions = false): MockDb {
 						meta: {},
 					};
 				},
-			} as unknown as D1PreparedStatement;
+		} as unknown as D1PreparedStatement & RecordedStatement;
+	};
+
+	return {
+		prepare(sql: string) {
+			return statement(sql);
 		},
 		batch: async (items: readonly D1PreparedStatement[]) => {
 			if (config.throwOnBatch) {
 				throw new Error("D1 write failed");
 			}
-			statements.push(...(items as unknown as RecordedStatement[]));
+			statements.push(
+				...(items as unknown as RecordedStatement[]).map((item) => ({
+					sql: item.sql,
+					params: item.params,
+				})),
+			);
 			return [] as unknown as D1Result[];
 		},
 		statements,
@@ -75,6 +104,10 @@ function expectRequestId(payload: { request_id?: unknown }): void {
 }
 
 describe("BranchOps AI Intake Worker", () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
 	it("returns the browser chat demo on GET /", async () => {
 		const request = new IncomingRequest("http://example.com/");
 		const ctx = createExecutionContext();
@@ -113,6 +146,12 @@ describe("BranchOps AI Intake Worker", () => {
 		expect(html).toContain("D1 Logging");
 		expect(html).toContain("CSV fields");
 		expect(html).toContain("ADMIN_EXPORT_TOKEN");
+		expect(html).toContain("Airtable Sync Queue");
+		expect(html).toContain("GET /admin/export/sync-queue");
+		expect(html).toContain("POST /admin/sync/airtable");
+		expect(html).toContain("AIRTABLE_API_KEY");
+		expect(html).toContain("AIRTABLE_BASE_ID");
+		expect(html).toContain("AIRTABLE_TABLE_NAME");
 		expect(html).toContain("Recommended use case");
 		expect(html).toContain("Prompt helper bullets");
 		expect(html).toContain("Raw /health JSON");
@@ -141,13 +180,20 @@ describe("BranchOps AI Intake Worker", () => {
 				chat: "POST /chat",
 				analyze: "POST /analyze",
 				admin_export_intake_leads: "GET /admin/export/intake-leads",
+				admin_export_sync_queue: "GET /admin/export/sync-queue",
+				admin_sync_airtable: "POST /admin/sync/airtable",
 			},
 			runtime_requirements: {
 				bindings: ["AI", "hello_ai_prod"],
-				vars: ["ADMIN_EXPORT_TOKEN optional for admin export"],
+				vars: [
+					"ADMIN_EXPORT_TOKEN optional for admin export",
+					"AIRTABLE_API_KEY optional for Airtable sync",
+					"AIRTABLE_BASE_ID optional for Airtable sync",
+					"AIRTABLE_TABLE_NAME optional for Airtable sync",
+				],
 			},
 		});
-		expect(payload.route_map).toHaveLength(5);
+		expect(payload.route_map).toHaveLength(7);
 		expect(payload.request_contracts.chat.content_type).toBe("application/json");
 		expect(payload.request_contracts.analyze.optional_fields).toEqual([
 			"mode",
@@ -199,6 +245,20 @@ describe("BranchOps AI Intake Worker", () => {
 			route: "/admin/export/intake-leads",
 			configured: false,
 			content_type: "text/csv",
+		});
+		expect(payload.airtable_sync).toMatchObject({
+			enabled: true,
+			configured: false,
+			required_vars: [
+				"AIRTABLE_API_KEY",
+				"AIRTABLE_BASE_ID",
+				"AIRTABLE_TABLE_NAME",
+			],
+			routes: {
+				queue_export: "GET /admin/export/sync-queue",
+				manual_sync: "POST /admin/sync/airtable",
+			},
+			destination: "airtable",
 		});
 	});
 
@@ -501,6 +561,16 @@ describe("BranchOps AI Intake Worker", () => {
 			"Automation Workflow",
 		]);
 		expect(lead?.params).not.toContain("Analyze this startup");
+		const syncQueue = db.statements.find((statement) =>
+			statement.sql.startsWith("INSERT INTO lead_sync_queue"),
+		);
+		expect(syncQueue?.params).toEqual([
+			payload.request_id,
+			"airtable",
+			"queued",
+			0,
+		]);
+		expect(syncQueue?.params).not.toContain("Analyze this startup");
 	});
 
 	it("rejects invalid analyze lead email", async () => {
@@ -860,6 +930,259 @@ describe("BranchOps AI Intake Worker", () => {
 		expect(csv).toContain('"req-123","Avery Founder","avery@example.com"');
 	});
 
+	it("returns 503 for sync queue export when token is not configured", async () => {
+		const request = new IncomingRequest(
+			"http://example.com/admin/export/sync-queue",
+		);
+		const ctx = createExecutionContext();
+		const response = await worker.fetch(request, createEnv({}), ctx);
+
+		await waitOnExecutionContext(ctx);
+		expect(response.status).toBe(503);
+		const payload = await response.json();
+		expectRequestId(payload);
+		expect(payload).toMatchObject({
+			ok: false,
+			error: "Admin export is not configured.",
+			route: "/admin/export/sync-queue",
+			required_env_var: "ADMIN_EXPORT_TOKEN",
+		});
+	});
+
+	it("requires bearer token for configured sync queue export", async () => {
+		const request = new IncomingRequest(
+			"http://example.com/admin/export/sync-queue",
+		);
+		const ctx = createExecutionContext();
+		const response = await worker.fetch(
+			request,
+			createEnv({}, createDbMock(), [], { ADMIN_EXPORT_TOKEN: "secret-token" }),
+			ctx,
+		);
+
+		await waitOnExecutionContext(ctx);
+		expect(response.status).toBe(401);
+		const payload = await response.json();
+		expectRequestId(payload);
+		expect(payload).toMatchObject({
+			ok: false,
+			error: "Unauthorized.",
+			route: "/admin/export/sync-queue",
+		});
+	});
+
+	it("exports sync queue records as JSON when bearer token is valid", async () => {
+		const request = new IncomingRequest(
+			"http://example.com/admin/export/sync-queue",
+			{
+				headers: {
+					authorization: "Bearer secret-token",
+				},
+			},
+		);
+		const ctx = createExecutionContext();
+		const response = await worker.fetch(
+			request,
+			createEnv(
+				{},
+				createDbMock({
+					queueRows: [
+						{
+							id: 1,
+							request_id: "req-123",
+							destination: "airtable",
+							status: "queued",
+							attempts: 0,
+							last_error: null,
+							created_at: "2026-04-29T00:00:00.000Z",
+							updated_at: "2026-04-29T00:00:00.000Z",
+						},
+					],
+				}),
+				[],
+				{ ADMIN_EXPORT_TOKEN: "secret-token" },
+			),
+			ctx,
+		);
+
+		await waitOnExecutionContext(ctx);
+		expect(response.status).toBe(200);
+		const payload = await response.json();
+		expectRequestId(payload);
+		expect(payload).toMatchObject({
+			ok: true,
+			data: {
+				records: [
+					{
+						id: 1,
+						request_id: "req-123",
+						destination: "airtable",
+						status: "queued",
+						attempts: 0,
+						last_error: null,
+					},
+				],
+			},
+		});
+		expect(JSON.stringify(payload)).not.toContain("secret-token");
+	});
+
+	it("requires bearer token for configured Airtable sync", async () => {
+		const request = new IncomingRequest("http://example.com/admin/sync/airtable", {
+			method: "POST",
+		});
+		const ctx = createExecutionContext();
+		const response = await worker.fetch(
+			request,
+			createEnv({}, createDbMock(), [], { ADMIN_EXPORT_TOKEN: "secret-token" }),
+			ctx,
+		);
+
+		await waitOnExecutionContext(ctx);
+		expect(response.status).toBe(401);
+		const payload = await response.json();
+		expectRequestId(payload);
+		expect(payload).toMatchObject({
+			ok: false,
+			error: "Unauthorized.",
+			route: "/admin/sync/airtable",
+		});
+	});
+
+	it("returns 503 for Airtable sync when Airtable vars are missing", async () => {
+		const request = new IncomingRequest("http://example.com/admin/sync/airtable", {
+			method: "POST",
+			headers: {
+				authorization: "Bearer secret-token",
+			},
+		});
+		const ctx = createExecutionContext();
+		const response = await worker.fetch(
+			request,
+			createEnv({}, createDbMock(), [], { ADMIN_EXPORT_TOKEN: "secret-token" }),
+			ctx,
+		);
+
+		await waitOnExecutionContext(ctx);
+		expect(response.status).toBe(503);
+		const payload = await response.json();
+		expectRequestId(payload);
+		expect(payload).toMatchObject({
+			ok: false,
+			error: "Airtable sync is not configured.",
+			route: "/admin/sync/airtable",
+			required_env_vars: [
+				"AIRTABLE_API_KEY",
+				"AIRTABLE_BASE_ID",
+				"AIRTABLE_TABLE_NAME",
+			],
+		});
+	});
+
+	it("syncs queued leads to Airtable and marks queue rows synced", async () => {
+		const airtableFetch = vi.fn(async () => {
+			return new Response(JSON.stringify({ records: [{ id: "rec-123" }] }), {
+				status: 200,
+				headers: {
+					"content-type": "application/json",
+				},
+			});
+		});
+		vi.stubGlobal("fetch", airtableFetch);
+
+		const request = new IncomingRequest("http://example.com/admin/sync/airtable", {
+			method: "POST",
+			headers: {
+				authorization: "Bearer secret-token",
+			},
+		});
+		const db = createDbMock({
+			syncRows: [
+				{
+					id: 1,
+					request_id: "req-123",
+					destination: "airtable",
+					status: "queued",
+					attempts: 0,
+					last_error: null,
+					created_at: "2026-04-29T00:00:00.000Z",
+					updated_at: "2026-04-29T00:00:00.000Z",
+					name: "Avery Founder",
+					email: "avery@example.com",
+					phone: "+1 555 0100",
+					business_name: "Avery Ops LLC",
+					location: "Detroit, MI",
+					preferred_contact: "email",
+					mode: "Automation Workflow",
+					lead_created_at: "2026-04-29T00:00:00.000Z",
+				},
+			],
+		});
+		const ctx = createExecutionContext();
+		const response = await worker.fetch(
+			request,
+			createEnv({}, db, [], {
+				ADMIN_EXPORT_TOKEN: "secret-token",
+				AIRTABLE_API_KEY: "fake-airtable-key",
+				AIRTABLE_BASE_ID: "appFakeBase",
+				AIRTABLE_TABLE_NAME: "Leads",
+			} as unknown as Partial<Env>),
+			ctx,
+		);
+
+		await waitOnExecutionContext(ctx);
+		expect(response.status).toBe(200);
+		const payload = await response.json();
+		expectRequestId(payload);
+		expect(payload).toMatchObject({
+			ok: true,
+			data: {
+				summary: {
+					processed: 1,
+					synced: 1,
+					failed: 0,
+					skipped: 0,
+				},
+			},
+		});
+		expect(airtableFetch).toHaveBeenCalledWith(
+			"https://api.airtable.com/v0/appFakeBase/Leads",
+			expect.objectContaining({
+				method: "POST",
+				headers: expect.objectContaining({
+					Authorization: "Bearer fake-airtable-key",
+					"Content-Type": "application/json",
+				}),
+				body: JSON.stringify({
+					records: [
+						{
+							fields: {
+								"Request ID": "req-123",
+								Name: "Avery Founder",
+								Email: "avery@example.com",
+								Phone: "+1 555 0100",
+								"Business Name": "Avery Ops LLC",
+								Location: "Detroit, MI",
+								"Preferred Contact": "email",
+								Mode: "Automation Workflow",
+								"Created At": "2026-04-29T00:00:00.000Z",
+							},
+						},
+					],
+				}),
+			}),
+		);
+		expect(db.statements).toEqual(
+			expect.arrayContaining([
+				{
+					sql: "UPDATE lead_sync_queue SET status = ?, attempts = attempts + 1, last_error = ?, updated_at = ? WHERE id = ?",
+					params: ["synced", null, expect.any(String), 1],
+				},
+			]),
+		);
+		expect(JSON.stringify(payload)).not.toContain("fake-airtable-key");
+	});
+
 	it("returns 404 on unknown routes", async () => {
 		const request = new IncomingRequest("http://example.com/unknown");
 		const ctx = createExecutionContext();
@@ -878,6 +1201,8 @@ describe("BranchOps AI Intake Worker", () => {
 				"POST /chat",
 				"POST /analyze",
 				"GET /admin/export/intake-leads",
+				"GET /admin/export/sync-queue",
+				"POST /admin/sync/airtable",
 			],
 		});
 	});


### PR DESCRIPTION
## Objective

Add an Airtable Lead Sync Queue to the BranchOps AI Intake Worker so captured D1 leads can be queued and manually synced to Airtable without exposing Airtable secrets in the browser.

## Asset

- Asset Name: BranchOps AI Intake Worker
- Asset ID: BOH-AI-INTAKE-001
- Owner: Branch Off Holdings LLC
- Runtime: Cloudflare Workers + Workers AI + D1

## Changes

- Added `lead_sync_queue` D1 table and indexes.
- Enqueued valid captured leads for Airtable sync.
- Added `GET /admin/export/sync-queue` for bearer-protected JSON queue export.
- Added `POST /admin/sync/airtable` for bearer-protected manual Airtable sync.
- Added safe `/health` metadata for Airtable sync configuration and required vars.
- Updated Export / Admin UI panel with Airtable Sync Queue details and required env vars.
- Added tests for queue creation, admin auth, missing Airtable config, health metadata, UI labels, and sync behavior.
- Updated README, operator SOP, asset register, and schema docs.

## Validation

- [x] npm run build
- [x] npm run validate — 24 tests passed
- [x] npm run deploy:dry-run
- [x] npm audit — 0 vulnerabilities

## Required Production Setup After Merge

Apply D1 schema:

```powershell
npx wrangler d1 execute hello-ai-prod --remote --file schema.sql
```

Set required secrets:

```powershell
npx wrangler secret put AIRTABLE_API_KEY
npx wrangler secret put AIRTABLE_BASE_ID
npx wrangler secret put AIRTABLE_TABLE_NAME
```

`ADMIN_EXPORT_TOKEN` must also be configured for the admin routes.

## Risk Controls

- No Airtable secrets hardcoded.
- No Airtable secrets exposed to browser.
- No browser token storage.
- Existing route contracts preserved.
- Manual sync is intentionally modest batch-only.
- Airtable target field names/types must match the table configuration.