### PR TITLE
Add BranchOps output utility layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This repository is the public-safe same-day intake Worker for BranchOps asset pl
 | Method | Path | Purpose | Contract |
 | --- | --- | --- | --- |
 | `GET` | `/` | Serve the browser intake/chat demo UI | HTML demo surface |
+| `GET` | `/output-utility` | Format generated BranchOps results for reuse | HTML output utility with copy/share/print/download actions |
 | `GET` | `/health` | Return status, asset metadata, route contracts, and runtime requirements | JSON metadata and route contracts |
 | `POST` | `/chat` | Run conversational chat and persist the transcript to D1 | `sessionId`, `reply`, `usage` |
 | `POST` | `/analyze` | Convert a raw idea into a structured BranchOps asset plan | BranchOps planning schema |
@@ -25,6 +26,17 @@ This repository is the public-safe same-day intake Worker for BranchOps asset pl
 | `POST` | `/admin/sync/airtable` | Manually sync queued lead records to Airtable | Bearer-token protected JSON summary |
 
 The browser UI is an app-style BranchOps workspace with a desktop sidebar, mobile menu behavior, structured analyzer panel, separate chat lane, lead capture panel, admin export panel, and system health panel.
+
+## Output Utility Layer
+
+Generated BranchOps results can be reused as business assets through the browser output actions on the structured result panel:
+
+- Copy Result
+- Share Result, using Web Share when available and copy fallback otherwise
+- Print / Save PDF through browser print
+- Download TXT
+
+`GET /output-utility` also serves a standalone formatter for pasted BranchOps JSON results. Both paths use the deterministic plain-text order documented in [BranchOps Output Format](docs/BRANCHOPS_OUTPUT_FORMAT.md). The utility does not add backend integrations, does not store results in third-party services, and redacts secret-like fields before export.
 
 ## UI Navigation
 

--- a/docs/BRANCHOPS_OUTPUT_FORMAT.md
+++ b/docs/BRANCHOPS_OUTPUT_FORMAT.md
@@ -1,0 +1,26 @@
+# BranchOps Output Format
+
+BranchOps generated results are formatted as plain text in this deterministic order:
+
+1. Request ID
+2. Mode
+3. Timestamp
+4. Objective
+5. Classification
+6. Asset
+7. Execution Plan
+8. Systems
+9. Monetization Model
+10. Automation Opportunities
+11. Legal / Compliance Risks
+12. Scaling Path
+13. Long-Term Value
+
+The formatter accepts root response fields and nested `result`, `analysis`, or `data` response shapes. It also maps compatible aliases:
+
+- `systems_and_prompts` -> Systems
+- `next_actions` -> Execution Plan
+- `risks` -> Legal / Compliance Risks
+- `createdAt` or `created_at` -> Timestamp
+
+Exports are plain text only. The output utility does not store results in a third-party service and does not add backend integrations. Secret-like nested fields and obvious credential-looking values are redacted before text export.

--- a/src/index.ts
+++ b/src/index.ts
@@ -149,6 +149,7 @@ const VERSION = "0.1.0";
 const MODEL = "@cf/openai/gpt-oss-120b";
 const ROUTES = {
 	root: "/",
+	outputUtility: "/output-utility",
 	health: "/health",
 	chat: "/chat",
 	analyze: "/analyze",
@@ -516,6 +517,22 @@ const CHAT_DEMO_HTML = `<!doctype html>
 			grid-template-columns: repeat(2, minmax(0, 1fr));
 			gap: 12px;
 		}
+		.output-actions {
+			display: flex;
+			flex-wrap: wrap;
+			gap: 10px;
+			margin: 10px 0 12px;
+		}
+		.output-status {
+			min-height: 20px;
+			margin-bottom: 10px;
+			color: #1d4ed8;
+			font-size: 0.88rem;
+			font-weight: 700;
+		}
+		.print-output {
+			display: none;
+		}
 		.result-card {
 			border: 1px solid #dbe3ed;
 			border-radius: 8px;
@@ -669,6 +686,31 @@ const CHAT_DEMO_HTML = `<!doctype html>
 				min-height: 0;
 			}
 		}
+		@media print {
+			body.output-printing {
+				background: #ffffff;
+			}
+			body.output-printing .mobile-topbar,
+			body.output-printing .sidebar,
+			body.output-printing .workspace-header,
+			body.output-printing .panel,
+			body.output-printing .actions,
+			body.output-printing button {
+				display: none !important;
+			}
+			body.output-printing .main {
+				padding: 0;
+			}
+			body.output-printing .print-output {
+				display: block !important;
+				white-space: pre-wrap;
+				color: #0f172a;
+				background: #ffffff;
+				border: 0;
+				max-height: none;
+				padding: 0;
+			}
+		}
 	</style>
 </head>
 <body>
@@ -808,6 +850,13 @@ const CHAT_DEMO_HTML = `<!doctype html>
 					<div class="panel">
 						<h3>Structured results</h3>
 						<p id="requestIdLine" class="muted">Request ID appears after analysis.</p>
+						<div class="output-actions" aria-label="BranchOps output actions">
+							<button id="copyResultBtn" class="secondary-button" type="button">Copy Result</button>
+							<button id="shareResultBtn" class="secondary-button" type="button">Share Result</button>
+							<button id="printResultBtn" class="secondary-button" type="button">Print / Save PDF</button>
+							<button id="downloadResultBtn" class="secondary-button" type="button">Download TXT</button>
+						</div>
+						<div id="outputActionStatus" class="output-status" role="status"></div>
 						<div id="resultCards" class="result-grid"></div>
 					</div>
 				</div>
@@ -885,6 +934,7 @@ const CHAT_DEMO_HTML = `<!doctype html>
 			</section>
 		</main>
 	</div>
+	<pre id="printOutput" class="print-output"></pre>
 
 	<script>
 		(function () {
@@ -967,6 +1017,8 @@ const CHAT_DEMO_HTML = `<!doctype html>
 			var instructionsInput = document.getElementById('instructionsInput');
 			var resultCards = document.getElementById('resultCards');
 			var requestIdLine = document.getElementById('requestIdLine');
+			var outputActionStatus = document.getElementById('outputActionStatus');
+			var printOutput = document.getElementById('printOutput');
 			var exportConfiguredStatus = document.getElementById('exportConfiguredStatus');
 			var intakeModeCount = document.getElementById('intakeModeCount');
 			var leadCaptureStatus = document.getElementById('leadCaptureStatus');
@@ -1013,6 +1065,22 @@ const CHAT_DEMO_HTML = `<!doctype html>
 				scaling_path: 'scaling_path',
 				long_term_value: 'long_term_value'
 			};
+			var outputFields = [
+				{ key: 'request_id', title: 'Request ID' },
+				{ key: 'mode', title: 'Mode' },
+				{ key: 'timestamp', title: 'Timestamp', aliases: ['createdAt', 'created_at'] },
+				{ key: 'objective', title: 'Objective' },
+				{ key: 'classification', title: 'Classification' },
+				{ key: 'asset', title: 'Asset' },
+				{ key: 'execution_plan', title: 'Execution Plan', aliases: ['next_actions'] },
+				{ key: 'systems', title: 'Systems', aliases: ['systems_and_prompts'] },
+				{ key: 'monetization_model', title: 'Monetization Model' },
+				{ key: 'automation_opportunities', title: 'Automation Opportunities' },
+				{ key: 'legal_compliance_risks', title: 'Legal / Compliance Risks', aliases: ['risks'] },
+				{ key: 'scaling_path', title: 'Scaling Path' },
+				{ key: 'long_term_value', title: 'Long-Term Value' }
+			];
+			var lastAnalyzeResult = null;
 			var sessionId = localStorage.getItem(SESSION_KEY) || crypto.randomUUID();
 			var messages = loadMessages();
 
@@ -1043,6 +1111,126 @@ const CHAT_DEMO_HTML = `<!doctype html>
 					return value;
 				}
 				return JSON.stringify(value, null, 2);
+			}
+
+			function cleanLabel(label) {
+				return label.replace(/([a-z0-9])([A-Z])/g, '$1 $2').replace(/[_-]+/g, ' ').trim().split(/\s+/).map(function (word) {
+					return word.charAt(0).toUpperCase() + word.slice(1);
+				}).join(' ');
+			}
+
+			function redactScalar(value) {
+				return String(value).replace(/sk-[A-Za-z0-9_-]{6,}/g, '[redacted sensitive value]').replace(/[A-Z0-9_]*(TOKEN|SECRET|API_KEY|PASSWORD)[A-Z0-9_]*\s*=\s*\S+/g, '[redacted sensitive value]');
+			}
+
+			function formatOutputValue(value, depth) {
+				depth = depth || 0;
+				if (value === null || value === undefined || value === '') {
+					return 'Not returned by backend.';
+				}
+				if (Array.isArray(value)) {
+					return value.length ? value.map(function (item) {
+						return '  '.repeat(depth) + '- ' + formatOutputValue(item, depth + 1).trimStart();
+					}).join('\n') : 'Not returned by backend.';
+				}
+				if (typeof value === 'object') {
+					var rows = Object.keys(value).filter(function (key) {
+						return !/(admin.*token|token|api.*key|secret|password|credential|private.*key)/i.test(key);
+					});
+					if (!rows.length) {
+						return 'Not returned by backend.';
+					}
+					return rows.map(function (key) {
+						var item = value[key];
+						if (item === null || typeof item !== 'object') {
+							return '  '.repeat(depth) + cleanLabel(key) + ': ' + formatOutputValue(item, depth);
+						}
+						return '  '.repeat(depth) + cleanLabel(key) + ':\n' + formatOutputValue(item, depth + 1);
+					}).join('\n');
+				}
+				return redactScalar(value);
+			}
+
+			function readOutputField(source, field) {
+				var names = [field.key].concat(field.aliases || []);
+				for (var index = 0; index < names.length; index += 1) {
+					if (source && Object.prototype.hasOwnProperty.call(source, names[index])) {
+						return source[names[index]];
+					}
+				}
+				return undefined;
+			}
+
+			function formatOutputText(result) {
+				var source = result && result.data ? result.data : {};
+				return outputFields.map(function (field) {
+					var value = field.key === 'request_id'
+						? result && result.request_id
+						: field.key === 'mode'
+							? currentMode()
+							: field.key === 'timestamp'
+								? new Date().toISOString()
+								: readOutputField(source, field);
+					return field.title + '\n' + formatOutputValue(value);
+				}).join('\n\n');
+			}
+
+			function currentOutputText() {
+				return lastAnalyzeResult ? formatOutputText(lastAnalyzeResult) : '';
+			}
+
+			async function copyResult() {
+				var text = currentOutputText();
+				if (!text) {
+					outputActionStatus.textContent = 'Run analysis before copying a result.';
+					return;
+				}
+				try {
+					await navigator.clipboard.writeText(text);
+					outputActionStatus.textContent = 'Result copied.';
+				} catch (error) {
+					outputActionStatus.textContent = 'Clipboard unavailable. Use Share Result instead.';
+				}
+			}
+
+			async function shareResult() {
+				var text = currentOutputText();
+				if (!text) {
+					outputActionStatus.textContent = 'Run analysis before sharing a result.';
+					return;
+				}
+				if (navigator.share) {
+					await navigator.share({ title: 'BranchOps Result', text: text });
+					outputActionStatus.textContent = 'Share sheet opened.';
+					return;
+				}
+				await copyResult();
+			}
+
+			function printResult() {
+				var text = currentOutputText();
+				if (!text) {
+					outputActionStatus.textContent = 'Run analysis before printing a result.';
+					return;
+				}
+				printOutput.textContent = text;
+				document.body.classList.add('output-printing');
+				window.print();
+			}
+
+			function downloadResult() {
+				var text = currentOutputText();
+				if (!text) {
+					outputActionStatus.textContent = 'Run analysis before downloading a result.';
+					return;
+				}
+				var blob = new Blob([text], { type: 'text/plain;charset=utf-8' });
+				var link = document.createElement('a');
+				link.href = URL.createObjectURL(blob);
+				link.download = 'branchops-result.txt';
+				link.click();
+				URL.revokeObjectURL(link.href);
+				outputActionStatus.textContent = 'TXT download prepared.';
 			}
 
 			function renderResultCards(data) {
@@ -1159,6 +1347,8 @@ const CHAT_DEMO_HTML = `<!doctype html>
 					return;
 				}
 				requestIdLine.textContent = 'Structuring intake...';
+				outputActionStatus.textContent = '';
+				lastAnalyzeResult = null;
 				renderResultCards({});
 				try {
 					var payload = Object.assign({
@@ -1187,6 +1377,7 @@ const CHAT_DEMO_HTML = `<!doctype html>
 						throw new Error(body.error || 'Analyze request failed.');
 					}
 					requestIdLine.textContent = 'Request ID: ' + body.request_id;
+					lastAnalyzeResult = body;
 					renderResultCards(body.data);
 				} catch (error) {
 					requestIdLine.textContent = 'Analyze error: ' + (error && error.message ? error.message : 'Unknown error');
@@ -1286,6 +1477,8 @@ const CHAT_DEMO_HTML = `<!doctype html>
 					leadInputs[key].value = '';
 				});
 				requestIdLine.textContent = 'Request ID appears after analysis.';
+				outputActionStatus.textContent = '';
+				lastAnalyzeResult = null;
 				renderResultCards({});
 			});
 
@@ -1312,6 +1505,13 @@ const CHAT_DEMO_HTML = `<!doctype html>
 			});
 
 			document.getElementById('refreshHealthBtn').addEventListener('click', loadHealth);
+			document.getElementById('copyResultBtn').addEventListener('click', copyResult);
+			document.getElementById('shareResultBtn').addEventListener('click', shareResult);
+			document.getElementById('printResultBtn').addEventListener('click', printResult);
+			document.getElementById('downloadResultBtn').addEventListener('click', downloadResult);
+			window.addEventListener('afterprint', function () {
+				document.body.classList.remove('output-printing');
+			});
 
 			modeSelect.addEventListener('change', function () {
 				applyMode(currentMode());
@@ -1323,6 +1523,153 @@ const CHAT_DEMO_HTML = `<!doctype html>
 			loadHealth();
 		})();
 	</script>
+</body>
+</html>`;
+
+const OUTPUT_UTILITY_HTML = `<!doctype html>
+<html lang="en">
+<head>
+	<meta charset="utf-8" />
+	<meta name="viewport" content="width=device-width, initial-scale=1" />
+	<title>BranchOps Output Utility</title>
+	<style>
+		:root { color-scheme: light; font-family: Arial, sans-serif; }
+		body { margin: 0; background: #f4f7fb; color: #0f172a; }
+		main { max-width: 920px; margin: 0 auto; padding: 32px 18px; }
+		h1 { font-size: 28px; margin: 0 0 8px; }
+		p { color: #475569; line-height: 1.5; }
+		textarea { width: 100%; min-height: 180px; border: 1px solid #cbd5e1; border-radius: 8px; padding: 12px; font: 14px/1.45 Consolas, monospace; box-sizing: border-box; }
+		button { border: 1px solid #cbd5e1; border-radius: 8px; background: #ffffff; color: #0f172a; cursor: pointer; font-weight: 700; min-height: 42px; padding: 0 14px; }
+		button.primary { background: #0f172a; color: #ffffff; }
+		.utility-toolbar { display: flex; flex-wrap: wrap; gap: 10px; margin: 14px 0; }
+		.result-output { background: #ffffff; border: 1px solid #dbe3ee; border-radius: 8px; padding: 18px; white-space: pre-wrap; }
+		.status { min-height: 22px; color: #1d4ed8; font-weight: 700; }
+		@media print {
+			body { background: #ffffff; }
+			main { max-width: none; padding: 0; }
+			.utility-toolbar, .result-input, .status, button { display: none !important; }
+			.result-output { border: 0; padding: 0; }
+		}
+	</style>
+</head>
+<body>
+<main>
+	<h1>BranchOps Output Utility</h1>
+	<p>Paste a BranchOps JSON result, format it as plain text, then copy, share, print, or download it.</p>
+	<section class="result-input">
+		<textarea id="source" aria-label="BranchOps JSON result" spellcheck="false"></textarea>
+		<div class="utility-toolbar">
+			<button class="primary" id="format" type="button">Format Result</button>
+			<button id="copy" type="button">Copy Result</button>
+			<button id="share" type="button">Share</button>
+			<button id="print" type="button">Print / Save PDF</button>
+			<button id="download" type="button">Download TXT</button>
+		</div>
+		<div class="status" id="status" role="status"></div>
+	</section>
+	<pre class="result-output" id="output">No formatted result yet.</pre>
+</main>
+<script>
+	(function () {
+		var fields = [
+			['request_id', 'Request ID'],
+			['mode', 'Mode'],
+			['timestamp', 'Timestamp', ['createdAt', 'created_at']],
+			['objective', 'Objective'],
+			['classification', 'Classification'],
+			['asset', 'Asset'],
+			['execution_plan', 'Execution Plan', ['next_actions']],
+			['systems', 'Systems', ['systems_and_prompts']],
+			['monetization_model', 'Monetization Model'],
+			['automation_opportunities', 'Automation Opportunities'],
+			['legal_compliance_risks', 'Legal / Compliance Risks', ['risks']],
+			['scaling_path', 'Scaling Path'],
+			['long_term_value', 'Long-Term Value']
+		];
+		var source = document.getElementById('source');
+		var output = document.getElementById('output');
+		var status = document.getElementById('status');
+		function resultSource(value) {
+			if (!value || typeof value !== 'object' || Array.isArray(value)) return {};
+			return value.result || value.analysis || value.data || value;
+		}
+		function label(value) {
+			return value.replace(/([a-z0-9])([A-Z])/g, '$1 $2').replace(/[_-]+/g, ' ').trim().split(/\\s+/).map(function (word) {
+				return word.charAt(0).toUpperCase() + word.slice(1);
+			}).join(' ');
+		}
+		function formatValue(value, depth) {
+			depth = depth || 0;
+			if (value === null || value === undefined || value === '') return 'Not returned by backend.';
+			if (Array.isArray(value)) return value.length ? value.map(function (item) { return '  '.repeat(depth) + '- ' + formatValue(item, depth + 1).trimStart(); }).join('\\n') : 'Not returned by backend.';
+			if (typeof value === 'object') {
+				var rows = Object.keys(value).filter(function (name) { return !/(admin.*token|token|api.*key|secret|password|credential|private.*key)/i.test(name); });
+				if (!rows.length) return 'Not returned by backend.';
+				return rows.map(function (name) {
+					var item = value[name];
+					if (item === null || typeof item !== 'object') return '  '.repeat(depth) + label(name) + ': ' + formatValue(item, depth);
+					return '  '.repeat(depth) + label(name) + ':\\n' + formatValue(item, depth + 1);
+				}).join('\\n');
+			}
+			return String(value).replace(/sk-[A-Za-z0-9_-]{6,}/g, '[redacted sensitive value]').replace(/[A-Z0-9_]*(TOKEN|SECRET|API_KEY|PASSWORD)[A-Z0-9_]*\\s*=\\s*\\S+/g, '[redacted sensitive value]');
+		}
+		function readField(sourceValue, field) {
+			var names = [field[0]].concat(field[2] || []);
+			for (var index = 0; index < names.length; index += 1) {
+				if (Object.prototype.hasOwnProperty.call(sourceValue, names[index])) return sourceValue[names[index]];
+			}
+			return undefined;
+		}
+		function formatResult() {
+			var value;
+			try {
+				value = JSON.parse(source.value || '{}');
+			} catch {
+				status.textContent = 'Enter valid JSON before formatting.';
+				return;
+			}
+			var data = resultSource(value);
+			output.textContent = fields.map(function (field) { return field[1] + '\\n' + formatValue(readField(data, field)); }).join('\\n\\n');
+			status.textContent = 'Formatted plain text is ready.';
+		}
+		async function copyResult() {
+			formatResult();
+			try {
+				await navigator.clipboard.writeText(output.textContent);
+				status.textContent = 'Copied.';
+			} catch {
+				source.value = output.textContent;
+				source.focus();
+				source.select();
+				status.textContent = 'Copy from the selected text.';
+			}
+		}
+		async function shareResult() {
+			formatResult();
+			if (navigator.share) {
+				await navigator.share({ title: 'BranchOps Result', text: output.textContent });
+				status.textContent = 'Share sheet opened.';
+				return;
+			}
+			await copyResult();
+		}
+		function downloadResult() {
+			formatResult();
+			var blob = new Blob([output.textContent], { type: 'text/plain;charset=utf-8' });
+			var link = document.createElement('a');
+			link.href = URL.createObjectURL(blob);
+			link.download = 'branchops-result.txt';
+			link.click();
+			URL.revokeObjectURL(link.href);
+			status.textContent = 'TXT file prepared.';
+		}
+		document.getElementById('format').addEventListener('click', formatResult);
+		document.getElementById('copy').addEventListener('click', copyResult);
+		document.getElementById('share').addEventListener('click', shareResult);
+		document.getElementById('print').addEventListener('click', function () { formatResult(); window.print(); });
+		document.getElementById('download').addEventListener('click', downloadResult);
+	})();
+</script>
 </body>
 </html>`;
 
@@ -2661,6 +3008,7 @@ function handleHealth(requestId: string, env: Env): Response {
 function handleMethodNotAllowed(pathname: string, requestId: string): Response {
 	const allowedMethod =
 		pathname === ROUTES.root ||
+		pathname === ROUTES.outputUtility ||
 		pathname === ROUTES.health ||
 		pathname === ROUTES.adminExportIntakeLeads ||
 		pathname === ROUTES.adminExportSyncQueue
@@ -3018,6 +3366,10 @@ export default {
 			return htmlResponse(CHAT_DEMO_HTML);
 		}
 
+		if (request.method === "GET" && url.pathname === ROUTES.outputUtility) {
+			return htmlResponse(OUTPUT_UTILITY_HTML);
+		}
+
 		if (request.method === "GET" && url.pathname === ROUTES.health) {
 			return handleHealth(requestId, env);
 		}
@@ -3277,6 +3629,7 @@ export default {
 
 		if (
 			url.pathname === ROUTES.root ||
+			url.pathname === ROUTES.outputUtility ||
 			url.pathname === ROUTES.health ||
 			url.pathname === ROUTES.chat ||
 			url.pathname === ROUTES.analyze ||

--- a/src/index.ts
+++ b/src/index.ts
@@ -1066,7 +1066,7 @@ const CHAT_DEMO_HTML = `<!doctype html>
 				long_term_value: 'long_term_value'
 			};
 			var outputFields = [
-				{ key: 'request_id', title: 'Request ID' },
+				{ key: 'request_id', title: 'Request ID', aliases: ['requestId'] },
 				{ key: 'mode', title: 'Mode' },
 				{ key: 'timestamp', title: 'Timestamp', aliases: ['createdAt', 'created_at'] },
 				{ key: 'objective', title: 'Objective' },
@@ -1161,16 +1161,21 @@ const CHAT_DEMO_HTML = `<!doctype html>
 				return undefined;
 			}
 
+			function outputSource(result) {
+				if (!result || typeof result !== 'object') {
+					return {};
+				}
+				var nested = result.result || result.analysis || result.data;
+				if (nested && typeof nested === 'object' && !Array.isArray(nested)) {
+					return Object.assign({}, result, nested);
+				}
+				return result;
+			}
+
 			function formatOutputText(result) {
-				var source = result && result.data ? result.data : {};
+				var source = outputSource(result);
 				return outputFields.map(function (field) {
-					var value = field.key === 'request_id'
-						? result && result.request_id
-						: field.key === 'mode'
-							? currentMode()
-							: field.key === 'timestamp'
-								? new Date().toISOString()
-								: readOutputField(source, field);
+					var value = readOutputField(source, field);
 					return field.title + '\n' + formatOutputValue(value);
 				}).join('\n\n');
 			}
@@ -1377,7 +1382,10 @@ const CHAT_DEMO_HTML = `<!doctype html>
 						throw new Error(body.error || 'Analyze request failed.');
 					}
 					requestIdLine.textContent = 'Request ID: ' + body.request_id;
-					lastAnalyzeResult = body;
+					lastAnalyzeResult = Object.assign({
+						mode: payload.mode,
+						timestamp: new Date().toISOString()
+					}, body);
 					renderResultCards(body.data);
 				} catch (error) {
 					requestIdLine.textContent = 'Analyze error: ' + (error && error.message ? error.message : 'Unknown error');
@@ -1572,7 +1580,7 @@ const OUTPUT_UTILITY_HTML = `<!doctype html>
 <script>
 	(function () {
 		var fields = [
-			['request_id', 'Request ID'],
+			['request_id', 'Request ID', ['requestId']],
 			['mode', 'Mode'],
 			['timestamp', 'Timestamp', ['createdAt', 'created_at']],
 			['objective', 'Objective'],
@@ -1591,7 +1599,11 @@ const OUTPUT_UTILITY_HTML = `<!doctype html>
 		var status = document.getElementById('status');
 		function resultSource(value) {
 			if (!value || typeof value !== 'object' || Array.isArray(value)) return {};
-			return value.result || value.analysis || value.data || value;
+			var nested = value.result || value.analysis || value.data;
+			if (nested && typeof nested === 'object' && !Array.isArray(nested)) {
+				return Object.assign({}, value, nested);
+			}
+			return value;
 		}
 		function label(value) {
 			return value.replace(/([a-z0-9])([A-Z])/g, '$1 $2').replace(/[_-]+/g, ' ').trim().split(/\\s+/).map(function (word) {

--- a/src/outputFormatter.ts
+++ b/src/outputFormatter.ts
@@ -1,0 +1,190 @@
+type ResultValue =
+	| string
+	| number
+	| boolean
+	| null
+	| undefined
+	| ResultValue[]
+	| { [key: string]: ResultValue };
+
+type BranchOpsOutputSource = {
+	requestId?: string;
+	mode?: string;
+	timestamp?: string;
+	result: unknown;
+};
+
+type OutputField = {
+	key: string;
+	title: string;
+	aliases?: string[];
+};
+
+export type BranchOpsOutputSection = {
+	key: string;
+	title: string;
+	value: string;
+};
+
+const EMPTY_VALUE = "Not returned by backend.";
+const REDACTED_VALUE = "[redacted sensitive value]";
+
+const OUTPUT_FIELDS: readonly OutputField[] = [
+	{ key: "request_id", title: "Request ID" },
+	{ key: "mode", title: "Mode" },
+	{ key: "timestamp", title: "Timestamp", aliases: ["createdAt", "created_at"] },
+	{ key: "objective", title: "Objective" },
+	{ key: "classification", title: "Classification" },
+	{ key: "asset", title: "Asset" },
+	{ key: "execution_plan", title: "Execution Plan", aliases: ["next_actions"] },
+	{ key: "systems", title: "Systems", aliases: ["systems_and_prompts"] },
+	{ key: "monetization_model", title: "Monetization Model" },
+	{ key: "automation_opportunities", title: "Automation Opportunities" },
+	{
+		key: "legal_compliance_risks",
+		title: "Legal / Compliance Risks",
+		aliases: ["risks"],
+	},
+	{ key: "scaling_path", title: "Scaling Path" },
+	{ key: "long_term_value", title: "Long-Term Value" },
+] as const;
+
+const SENSITIVE_KEY_PATTERN =
+	/(admin.*token|token|api.*key|secret|password|credential|private.*key)/i;
+const SENSITIVE_VALUE_PATTERN =
+	/(sk-[A-Za-z0-9_-]{6,}|[A-Z0-9_]*(TOKEN|SECRET|API_KEY|PASSWORD)[A-Z0-9_]*\s*=\s*\S+)/g;
+
+export function buildBranchOpsOutputSections({
+	requestId,
+	mode,
+	timestamp,
+	result,
+}: BranchOpsOutputSource): BranchOpsOutputSection[] {
+	const source = readResultSource(result);
+
+	return OUTPUT_FIELDS.map((field) => {
+		const metadataValue =
+			field.key === "request_id"
+				? requestId ?? readField(source, field)
+				: field.key === "mode"
+					? mode ?? readField(source, field)
+					: field.key === "timestamp"
+						? timestamp ?? readField(source, field)
+						: readField(source, field);
+
+		return {
+			key: field.key,
+			title: field.title,
+			value: formatResultValue(metadataValue),
+		};
+	});
+}
+
+export function formatBranchOpsOutputText(input: BranchOpsOutputSource): string {
+	return buildBranchOpsOutputSections(input)
+		.map((section) => `${section.title}\n${section.value}`)
+		.join("\n\n");
+}
+
+export function formatResultValue(value: ResultValue, depth = 0): string {
+	if (value === null || value === undefined || value === "") {
+		return EMPTY_VALUE;
+	}
+
+	if (Array.isArray(value)) {
+		const items = value
+			.map((item) => formatArrayItem(item, depth))
+			.filter((item) => item.trim().length > 0);
+		return items.length > 0 ? items.join("\n") : EMPTY_VALUE;
+	}
+
+	if (typeof value === "object") {
+		const entries = Object.entries(value).filter(
+			([key]) => !SENSITIVE_KEY_PATTERN.test(key),
+		);
+
+		if (entries.length === 0) {
+			return EMPTY_VALUE;
+		}
+
+		const indent = "  ".repeat(depth);
+		return entries
+			.map(([key, item]) => {
+				const label = cleanResultLabel(key);
+
+				if (isScalarResult(item)) {
+					return `${indent}${label}: ${formatScalar(item)}`;
+				}
+
+				return `${indent}${label}:\n${formatResultValue(item, depth + 1)}`;
+			})
+			.join("\n");
+	}
+
+	return formatScalar(value);
+}
+
+export function cleanResultLabel(label: string) {
+	return label
+		.replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+		.replace(/[_-]+/g, " ")
+		.trim()
+		.split(/\s+/)
+		.map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+		.join(" ");
+}
+
+function readResultSource(value: unknown): Record<string, ResultValue> | undefined {
+	if (!isRecord(value)) {
+		return undefined;
+	}
+
+	for (const key of ["result", "analysis", "data"] as const) {
+		if (isRecord(value[key])) {
+			return value[key] as Record<string, ResultValue>;
+		}
+	}
+
+	return value as Record<string, ResultValue>;
+}
+
+function readField(source: Record<string, ResultValue> | undefined, field: OutputField) {
+	if (!source) {
+		return undefined;
+	}
+
+	const keys = [field.key, ...(field.aliases ?? [])];
+	for (const key of keys) {
+		if (key in source) {
+			return source[key];
+		}
+	}
+
+	return undefined;
+}
+
+function formatArrayItem(item: ResultValue, depth: number) {
+	const indent = "  ".repeat(depth);
+
+	if (isScalarResult(item)) {
+		return `${indent}- ${formatScalar(item)}`;
+	}
+
+	return `${indent}- ${formatResultValue(item, depth + 1).trimStart()}`;
+}
+
+function formatScalar(value: string | number | boolean | null | undefined) {
+	if (value === null || value === undefined || value === "") {
+		return EMPTY_VALUE;
+	}
+
+	return String(value).replace(SENSITIVE_VALUE_PATTERN, REDACTED_VALUE);
+}
+
+function isScalarResult(value: ResultValue) {
+	return value === null || value === undefined || typeof value !== "object";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}

--- a/src/outputFormatter.ts
+++ b/src/outputFormatter.ts
@@ -30,7 +30,7 @@ const EMPTY_VALUE = "Not returned by backend.";
 const REDACTED_VALUE = "[redacted sensitive value]";
 
 const OUTPUT_FIELDS: readonly OutputField[] = [
-	{ key: "request_id", title: "Request ID" },
+	{ key: "request_id", title: "Request ID", aliases: ["requestId"] },
 	{ key: "mode", title: "Mode" },
 	{ key: "timestamp", title: "Timestamp", aliases: ["createdAt", "created_at"] },
 	{ key: "objective", title: "Objective" },
@@ -141,7 +141,10 @@ function readResultSource(value: unknown): Record<string, ResultValue> | undefin
 
 	for (const key of ["result", "analysis", "data"] as const) {
 		if (isRecord(value[key])) {
-			return value[key] as Record<string, ResultValue>;
+			return {
+				...(value as Record<string, ResultValue>),
+				...(value[key] as Record<string, ResultValue>),
+			};
 		}
 	}
 

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -141,6 +141,11 @@ describe("BranchOps AI Intake Worker", () => {
 		expect(html).toContain("Preferred contact");
 		expect(html).toContain("Analyze intake");
 		expect(html).toContain("Structured results");
+		expect(html).toContain("Copy Result");
+		expect(html).toContain("Share Result");
+		expect(html).toContain("Print / Save PDF");
+		expect(html).toContain("Download TXT");
+		expect(html).toContain("@media print");
 		expect(html).toContain("Request ID");
 		expect(html).toContain("Throttle Limit");
 		expect(html).toContain("D1 Logging");
@@ -155,6 +160,27 @@ describe("BranchOps AI Intake Worker", () => {
 		expect(html).toContain("Recommended use case");
 		expect(html).toContain("Prompt helper bullets");
 		expect(html).toContain("Raw /health JSON");
+	});
+
+	it("serves the standalone output utility without changing health contracts", async () => {
+		const request = new IncomingRequest("http://example.com/output-utility");
+		const ctx = createExecutionContext();
+		const response = await worker.fetch(request, createEnv({}), ctx);
+
+		await waitOnExecutionContext(ctx);
+		expect(response.status).toBe(200);
+		expect(response.headers.get("content-type")).toContain("text/html");
+		const html = await response.text();
+		expect(html).toContain("<title>BranchOps Output Utility</title>");
+		expect(html).toContain("Copy Result");
+		expect(html).toContain("Share");
+		expect(html).toContain("Print / Save PDF");
+		expect(html).toContain("Download TXT");
+		expect(html).toContain("navigator.share");
+		expect(html).toContain("@media print");
+		expect(html).not.toContain("ADMIN_EXPORT_TOKEN");
+		expect(html).not.toContain("AIRTABLE_API_KEY");
+		expect(html).not.toContain("CLOUDFLARE_API_TOKEN");
 	});
 
 	it("returns an explicit route map on GET /health", async () => {

--- a/test/outputFormatter.spec.ts
+++ b/test/outputFormatter.spec.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import { formatBranchOpsOutputText } from "../src/outputFormatter";
+
+describe("BranchOps output formatter", () => {
+	it("formats generated results in deterministic business-asset order", () => {
+		const text = formatBranchOpsOutputText({
+			requestId: "req_123",
+			mode: "Automation Workflow",
+			timestamp: "2026-05-14T15:30:00.000Z",
+			result: {
+				objective: "Launch an operator follow-up system.",
+				classification: "Automation",
+				asset: "Lead routing playbook",
+				execution_plan: ["Capture leads", "Send follow-up"],
+				systems: ["BranchOps intake worker"],
+				monetization_model: { primary: "subscription" },
+				automation_opportunities: ["Auto-classify requests"],
+				legal_compliance_risks: ["Review consent copy"],
+				scaling_path: ["Pilot locally", "Expand by vertical"],
+				long_term_value: "Reusable lead conversion asset.",
+			},
+		});
+
+		expect(text.split("\n\n").map((section) => section.split("\n")[0])).toEqual([
+			"Request ID",
+			"Mode",
+			"Timestamp",
+			"Objective",
+			"Classification",
+			"Asset",
+			"Execution Plan",
+			"Systems",
+			"Monetization Model",
+			"Automation Opportunities",
+			"Legal / Compliance Risks",
+			"Scaling Path",
+			"Long-Term Value",
+		]);
+		expect(text).toContain("- Capture leads");
+		expect(text).toContain("Primary: subscription");
+	});
+
+	it("maps legacy aliases without changing the analyze contract", () => {
+		const text = formatBranchOpsOutputText({
+			result: {
+				request_id: "req_alias",
+				mode: "General Business Asset",
+				created_at: "2026-05-14T15:30:00.000Z",
+				next_actions: ["Draft the first offer"],
+				systems_and_prompts: ["Prompt library"],
+				risks: ["Review claims"],
+			},
+		});
+
+		expect(text).toContain("Request ID\nreq_alias");
+		expect(text).toContain("Execution Plan\n- Draft the first offer");
+		expect(text).toContain("Systems\n- Prompt library");
+		expect(text).toContain("Legal / Compliance Risks\n- Review claims");
+	});
+
+	it("keeps missing fields explicit in the export", () => {
+		const text = formatBranchOpsOutputText({
+			requestId: "req_missing",
+			result: {
+				objective: "Prepare a reusable export.",
+			},
+		});
+
+		expect(text).toContain("Classification\nNot returned by backend.");
+		expect(text).toContain("Long-Term Value\nNot returned by backend.");
+	});
+
+	it("redacts secret-like values from formatted exports", () => {
+		const text = formatBranchOpsOutputText({
+			requestId: "req_456",
+			mode: "General Business Asset",
+			result: {
+				objective: "Prepare a safe export.",
+				classification: "Compliance",
+				monetization_model: {
+					admin_token: "adm-secret-token",
+					public_summary: "Membership revenue",
+				},
+				legal_compliance_risks: ["Never print OPENAI_API_KEY=sk-test-secret"],
+			},
+		});
+
+		expect(text).toContain("[redacted sensitive value]");
+		expect(text).toContain("Public Summary: Membership revenue");
+		expect(text).not.toContain("adm-secret-token");
+		expect(text).not.toContain("sk-test-secret");
+	});
+});

--- a/test/outputFormatter.spec.ts
+++ b/test/outputFormatter.spec.ts
@@ -58,6 +58,28 @@ describe("BranchOps output formatter", () => {
 		expect(text).toContain("Legal / Compliance Risks\n- Review claims");
 	});
 
+	it("reads root metadata fields while formatting nested response data", () => {
+		const text = formatBranchOpsOutputText({
+			result: {
+				request_id: "req_nested",
+				mode: "Operator Intake",
+				createdAt: "2026-05-14T16:00:00.000Z",
+				data: {
+					objective: "Turn the generated plan into a reusable asset.",
+					classification: "Business Asset",
+				},
+			},
+		});
+
+		expect(text).toContain("Request ID\nreq_nested");
+		expect(text).toContain("Mode\nOperator Intake");
+		expect(text).toContain("Timestamp\n2026-05-14T16:00:00.000Z");
+		expect(text).toContain(
+			"Objective\nTurn the generated plan into a reusable asset.",
+		);
+		expect(text).toContain("Classification\nBusiness Asset");
+	});
+
 	it("keeps missing fields explicit in the export", () => {
 		const text = formatBranchOpsOutputText({
 			requestId: "req_missing",

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -5,6 +5,7 @@ export default defineConfig({
     plugins: [
         cloudflareTest({
             wrangler: { configPath: "./wrangler.jsonc" },
+            remoteBindings: false,
         }),
     ],
 });


### PR DESCRIPTION
## Scope

Repairs PR #22 against `feat/worker-contract-hardened` and narrows the diff back to Issue #21.

Preserved in this PR:
- Deterministic BranchOps plain-text output formatter
- Browser result actions: Copy Result, Web Share with copy fallback, Print / Save PDF, Download TXT
- Additive `GET /output-utility` standalone formatter page
- Print CSS that hides navigation/sidebar/buttons and prints only formatted output
- `docs/BRANCHOPS_OUTPUT_FORMAT.md`
- Tests for output order, alias handling, nested/root response metadata, missing fields, redaction, and no secret/admin token exposure in the utility page

Removed from the prior PR branch diff:
- Broader route-contract changes outside Issue #21
- `/classify` and `/branchops-plan` route work
- `package.json` script changes
- Large README rewrite
- Any Worker naming/config deployment changes

## Route Contract Safety

Existing route contracts are preserved:
- `GET /`
- `GET /health`
- `POST /chat`
- `POST /analyze`
- Existing admin routes

`GET /output-utility` is additive and does not change `/health`, `/chat`, `/analyze`, or admin request/response contracts.

## Validation

Run locally on the final repaired branch head `f73f677` on May 14, 2026:

- `npm test -- --run` - PASS, 2 test files, 30 tests
- `npm run build` - PASS, `tsc --noEmit`
- `npm run deploy:dry-run` - PASS, Wrangler dry-run upload succeeded and exited without deploy
- `git diff --check` - PASS, no whitespace errors

Mergeability checks:
- GitHub connector reports PR #22 `mergeable: true` after the final push
- Local `git merge-tree` against `origin/feat/worker-contract-hardened` completed without conflicts

Note: `vitest.config.mts` sets `remoteBindings: false` so the Cloudflare Vitest pool runs locally without requiring a Wrangler remote login. `wrangler.jsonc` and the deployed Worker name are unchanged.

Closes #21